### PR TITLE
contractの修正

### DIFF
--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -79,7 +79,7 @@ contract Knowtfolio is
         return newItemId;
     }
 
-    function isOwnerOf(address editor, string memory articleId)
+    function isOwnerOfArticle(address editor, string memory articleId)
         public
         view
         onlyOwner

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -16,6 +16,8 @@ contract Knowtfolio is
     using CountersUpgradeable for CountersUpgradeable.Counter;
     CountersUpgradeable.Counter internal _tokenIds;
 
+    mapping(string => uint256) internal tokenIdOf;
+
     function _beforeTokenTransfer(
         address from,
         address to,
@@ -61,16 +63,18 @@ contract Knowtfolio is
         __Ownable_init();
     }
 
-    function mintNFT(address recipient, string memory _tokenURI)
-        public
-        onlyOwner
-        returns (uint256)
-    {
+    function mintNFT(
+        address recipient,
+        string memory _tokenURI,
+        string memory _articleId
+    ) public onlyOwner returns (uint256) {
+        require(bytes(_articleId).length > 0 && tokenIdOf[_articleId] != 0);
         _tokenIds.increment();
 
         uint256 newItemId = _tokenIds.current();
         _mint(recipient, newItemId);
         _setTokenURI(newItemId, _tokenURI);
+        tokenIdOf[_articleId] = newItemId;
 
         return newItemId;
     }

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -78,4 +78,16 @@ contract Knowtfolio is
 
         return newItemId;
     }
+
+    function isOwnerOf(address editor, string memory articleId)
+        public
+        view
+        onlyOwner
+        returns (bool)
+    {
+        uint256 _tokenId = tokenIdOf[articleId];
+        require(_tokenId != 0);
+        address owner = ownerOf(_tokenId);
+        return owner == editor;
+    }
 }

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -68,7 +68,7 @@ contract Knowtfolio is
         string memory _tokenURI,
         string memory _articleId
     ) public onlyOwner returns (uint256) {
-        require(bytes(_articleId).length > 0 && tokenIdOf[_articleId] != 0);
+        require(bytes(_articleId).length > 0 && tokenIdOf[_articleId] == 0);
         _tokenIds.increment();
 
         uint256 newItemId = _tokenIds.current();


### PR DESCRIPTION
- articleId => tokenID のmappingを作成した
  - mintする際に、articleIdを引数に入れた
    - articleIdは１文字以上の文字列
  - mintする際に、mapの衝突をチェックした上で、mapにarticleIdをtokenIdを保存する
- isOwnerOfArticleでarticleIdとaddressから編集権があるかチェック
