### PR TITLE
ServerをDockerで立ち上げられるように

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOA_DESIGN_DIR = $(GOA_DIR)/design
 GOA_GEN_DIR = $(GOA_DIR)/gen
 GOA_DOCKER_FILE = ./server/goa.Dockerfile
 
-.PHONY: goa
+.PHONY: goa server
 
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker build -t knowtfolio/goa-gen -f $(GOA_DOCKER_FILE) ./server
@@ -12,6 +12,9 @@ $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 		-o /$(GOA_DIR)
 
 goa: $(GOA_GEN_DIR)
+
+server:
+	docker-compose up --build server
 
 clean:
 	rm -rf $(GOA_GEN_DIR)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Blogging platform that leverages NFT to grow, buy and sell articles.
 
 ## Run
 
+### Start Backend Server & Database
+```bash
+make server
+```
+
 ### Generate OpenAPI docs
 ```bash
 make goa

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,19 @@
 version: '3.0'
 services:
+  server:
+    build: server
+    ports:
+      - "8080:8080"
+    command: bash -c "
+      /scripts/wait-for-it.sh db:3306 --timeout=60 --strict &&
+      go run main.go"
+    volumes:
+      - type: bind
+        source: ./server
+        target: /server
+    depends_on:
+      - db
+
   db:
     image: mysql:8.0.29
     platform: linux/amd64 # For M1 mac...

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.18.3
+
+WORKDIR /server
+
+ARG GOPATH=/go
+
+RUN mkdir /scripts \
+    && wget 'https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh' -P /scripts  \
+    && chmod 755 /scripts/wait-for-it.sh
+
+COPY go.mod go.sum /server/
+RUN go mod download

--- a/server/main.go
+++ b/server/main.go
@@ -11,7 +11,7 @@ func main() {
 	logger := services.NewLogger("main", true)
 
 	handler := services.NewHttpHandler()
-	db, err := gorm.Open(mysql.Open("root:password@tcp(localhost:3306)/knowtfolio-db?parseTime=true"))
+	db, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/knowtfolio-db?parseTime=true"), &gorm.Config{})
 	logger.Err(err)
 
 	handler.AddService(services.NewArticlesService(db, *handler), "articles")


### PR DESCRIPTION
docker-composeのサービスに`server`を追加し、`make server`でGoa の自動生成、DBの起動、サーバのきどうまで全て行えるようになった