### PR TITLE
`server`起動前に、`goa`ファイルを自動生成する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 
 goa: $(GOA_GEN_DIR)
 
-server:
+server: goa
 	docker-compose up --build server
 
 clean:


### PR DESCRIPTION
#18 の積み残し