### PR TITLE
バックエンドのDockerサービス化

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOA_DESIGN_DIR = $(GOA_DIR)/design
 GOA_GEN_DIR = $(GOA_DIR)/gen
 GOA_DOCKER_FILE = ./server/goa.Dockerfile
 
-.PHONY: goa
+.PHONY: goa server
 
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker build -t knowtfolio/goa-gen -f $(GOA_DOCKER_FILE) ./server
@@ -13,8 +13,8 @@ $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 
 goa: $(GOA_GEN_DIR)
 
+server: goa
+	docker-compose up --build server
+
 clean:
 	rm -rf $(GOA_GEN_DIR)
-
-client-server:
-	cd client && npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,21 @@
 version: '3.0'
 services:
+  server:
+    build: server
+    ports:
+      - "8080:8080"
+    command: bash -c "
+      /scripts/wait-for-it.sh db:3306 --timeout=60 --strict &&
+      go run main.go"
+    env_file:
+      - ./server/.env
+    volumes:
+      - type: bind
+        source: ./server
+        target: /server
+    depends_on:
+      - db
+
   db:
     image: mysql:8.0.29
     platform: linux/amd64 # For M1 mac...

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.18.3
+
+WORKDIR /server
+
+ARG GOPATH=/go
+
+RUN mkdir /scripts \
+    && wget 'https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh' -P /scripts  \
+    && chmod 755 /scripts/wait-for-it.sh
+
+COPY go.mod go.sum /server/
+RUN go mod download

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,9 @@ func main() {
 
 	// Connect to DB
 	db, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/knowtfolio-db?parseTime=true"), &gorm.Config{})
-	logger.Err(err)
+	if err != nil {
+		logger.Fatal().Msgf("Failed to connect with DB: %v", err)
+	}
 
 	handler := services.NewHttpHandler()
 	handler.AddService(services.NewArticlesService(db, *handler), "articles")

--- a/server/main.go
+++ b/server/main.go
@@ -10,10 +10,11 @@ import (
 func main() {
 	logger := services.NewLogger("main", true)
 
-	handler := services.NewHttpHandler()
-	db, err := gorm.Open(mysql.Open("root:password@tcp(localhost:3306)/knowtfolio-db?parseTime=true"))
+	// Connect to DB
+	db, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/knowtfolio-db?parseTime=true"), &gorm.Config{})
 	logger.Err(err)
 
+	handler := services.NewHttpHandler()
 	handler.AddService(services.NewArticlesService(db, *handler), "articles")
 	handler.AddService(services.NewArticlesHtmlService(db, *handler), "articles-html")
 


### PR DESCRIPTION
* docker-composeのターゲットに`server`を追加
* バックエンドコードで、DBのホストネームを`localhost`から`db`（コンテナ上からはこうアクセスする必要がある）に変更
* makeでもサーバを起動できるように