### PR TITLE
記事作成/編集ページの実装

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,7 +9,7 @@ import Header from "./components/organisms/Header";
 import NotFound from "./components/pages/NofFound";
 import NewArticlePage from "./components/pages/NewArticlePage";
 import EditArticlePage from "./components/pages/EditArticlePage";
-import Web3Provider from "./components/organisms/Web3Provider";
+import Web3Provider from "./components/organisms/providers/Web3Provider";
 
 const App = () => {
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,7 +37,9 @@ const App = () => {
               </AuthProvider>
             }
           />
+          {/* TODO: chenage endipoint to /articles/new */}
           <Route path="/new" element={<NewArticlePage />} />
+          {/* TODO: chenage endipoint to /articles/:articleId/edit */}
           <Route path="/edit/:articleId" element={<EditArticlePage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,34 +7,41 @@ import AuthProvider from "./components/organisms/providers/AuthProvider";
 import ImageUpload from "./components/pages/ImageUpload";
 import Header from "./components/organisms/Header";
 import NotFound from "./components/pages/NofFound";
+import NewArticlePage from "./components/pages/NewArticlePage";
+import EditArticlePage from "./components/pages/EditArticlePage";
+import Web3Provider from "./components/organisms/Web3Provider";
 
 const App = () => {
   return (
     <>
       <Header />
       <hr />
-      <Routes>
-        <Route path="/" element={<HelloWeb3 />} />
-        <Route path="/signup" element={<SignUp />} />
-        <Route path="/signin" element={<SignIn />} />
-        <Route
-          path="/mypage"
-          element={
-            <AuthProvider>
-              <Mypage />
-            </AuthProvider>
-          }
-        />
-        <Route
-          path="/image-upload"
-          element={
-            <AuthProvider>
-              <ImageUpload />
-            </AuthProvider>
-          }
-        />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Web3Provider>
+        <Routes>
+          <Route path="/" element={<HelloWeb3 />} />
+          <Route path="/signup" element={<SignUp />} />
+          <Route path="/signin" element={<SignIn />} />
+          <Route
+            path="/mypage"
+            element={
+              <AuthProvider>
+                <Mypage />
+              </AuthProvider>
+            }
+          />
+          <Route
+            path="/image-upload"
+            element={
+              <AuthProvider>
+                <ImageUpload />
+              </AuthProvider>
+            }
+          />
+          <Route path="/new" element={<NewArticlePage />} />
+          <Route path="/edit/:articleId" element={<EditArticlePage />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Web3Provider>
     </>
   );
 };

--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -52,7 +52,7 @@ type mintArticleNftForm = {
   signature: string;
 };
 export const mintArticleNft = async (form: mintArticleNftForm) => {
-  await axios.post(`/api/articles/${form.articleId}/nft`, {
+  await axios.post(`/api/nfts/${form.articleId}`, {
     address: form.address,
     signature: form.signature,
   });

--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -25,7 +25,7 @@ export const postArticle = async (form: postArticleForm) => {
 export type updateArticleForm = {
   articleId: string;
 } & postArticleForm;
-export const updateArticle = async (form: updateArticleForm) => {
+export const putArticle = async (form: updateArticleForm) => {
   await axios.put(`/api/articles/${form.articleId}`, {
     address: form.address,
     content: form.content,

--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -1,0 +1,59 @@
+import axios from "axios";
+
+export type postArticleForm = {
+  address: string;
+  content: string;
+  signature: string;
+  title: string;
+};
+
+type postArticleResponse = {
+  content: string;
+  id: string;
+  title: string;
+};
+export const postArticle = async (form: postArticleForm) => {
+  const { data } = await axios.post<postArticleResponse>("/api/articles", {
+    address: form.address,
+    content: form.content,
+    signature: form.signature,
+    title: form.title,
+  });
+  return data;
+};
+
+export type updateArticleForm = {
+  articleId: string;
+} & postArticleForm;
+export const updateArticle = async (form: updateArticleForm) => {
+  await axios.put(`/api/articles/${form.articleId}`, {
+    address: form.address,
+    content: form.content,
+    signature: form.signature,
+    title: form.title,
+  });
+};
+
+type getArticleResponse = {
+  id: string;
+  content: string;
+  title: string;
+};
+export const getArticle = async (articleId: string) => {
+  const { data } = await axios.get<getArticleResponse>(
+    `/api/articles/${articleId}`
+  );
+  return data;
+};
+
+type mintArticleNftForm = {
+  articleId: string;
+  address: string;
+  signature: string;
+};
+export const mintArticleNft = async (form: mintArticleNftForm) => {
+  await axios.post(`/api/articles/${form.articleId}/nft`, {
+    address: form.address,
+    signature: form.signature,
+  });
+};

--- a/client/src/apis/s3.ts
+++ b/client/src/apis/s3.ts
@@ -1,0 +1,27 @@
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { fromCognitoIdentityPool } from "@aws-sdk/credential-providers";
+import { COGNITO_USER_POOL_ID } from "~/configs/cognito";
+import { COGNITO_IDENTITY_POOL_ID, getS3Client } from "~/configs/s3";
+
+export const getS3ClientWithCognitoJwtToken = (jwtToken: string) => {
+  return getS3Client(
+    fromCognitoIdentityPool({
+      identityPoolId: COGNITO_IDENTITY_POOL_ID,
+      logins: {
+        [`cognito-idp.ap-northeast-1.amazonaws.com/${COGNITO_USER_POOL_ID}`]:
+          jwtToken,
+      },
+      clientConfig: {
+        region: "ap-northeast-1",
+      },
+    })
+  );
+};
+
+export const createPutImageObjectCommand = (key: string, blob: Blob) => {
+  return new PutObjectCommand({
+    Bucket: "knowtfolio-alpha",
+    Key: key,
+    Body: blob,
+  });
+};

--- a/client/src/components/organisms/Web3Provider/index.tsx
+++ b/client/src/components/organisms/Web3Provider/index.tsx
@@ -1,0 +1,73 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import detectEthereumProvider from "@metamask/detect-provider";
+import Web3 from "web3";
+
+type web3Context = {
+  web3: Web3;
+  account: string;
+};
+const web3Context = createContext<web3Context>({} as web3Context);
+
+type props = {
+  children: React.ReactNode;
+};
+const Web3Provider = ({ children }: props) => {
+  const [web3Obj, setWeb3Obj] = useState<web3Context | null>(null);
+
+  useEffect(() => {
+    // Reload when account is changed
+    window.ethereum.on("accountsChanged", () => {
+      // Handle the new accounts, or lack thereof.
+      window.location.reload();
+    });
+    // Reload when chain is changed
+    window.ethereum.on("chainChanged", () => {
+      // Handle the new chain.
+      window.location.reload();
+    });
+  }, []);
+
+  const connectMetamask = useCallback(async () => {
+    const provider = await detectEthereumProvider({ mustBeMetaMask: true });
+    if (provider && window.ethereum?.isMetaMask) {
+      console.log("Welcome to MetaMask User🎉");
+      const web3 = new Web3(Web3.givenProvider);
+      // connect with metamask wallet
+      const accounts = await web3.eth.requestAccounts();
+      const account = accounts[0];
+
+      setWeb3Obj({
+        web3,
+        account,
+      });
+    } else {
+      console.log("Please Install MetaMask🙇‍♂️");
+    }
+  }, []);
+
+  // Initialize connection with contract and wallet
+  useEffect(() => {
+    connectMetamask();
+  }, [connectMetamask]);
+
+  return (
+    <>
+      {web3Obj ? (
+        <web3Context.Provider value={web3Obj}>{children}</web3Context.Provider>
+      ) : (
+        <div>metamaskに接続してください</div>
+      )}
+    </>
+  );
+};
+
+export default Web3Provider;
+export const useWeb3 = () => {
+  return useContext(web3Context);
+};

--- a/client/src/components/organisms/providers/Web3Provider/index.tsx
+++ b/client/src/components/organisms/providers/Web3Provider/index.tsx
@@ -8,6 +8,8 @@ import {
 import detectEthereumProvider from "@metamask/detect-provider";
 import Web3 from "web3";
 
+const defaultContentOnUnconnected = <div>metamaskに接続してください</div>;
+
 type web3Context = {
   web3: Web3;
   account: string;
@@ -16,8 +18,12 @@ const web3Context = createContext<web3Context>({} as web3Context);
 
 type props = {
   children: React.ReactNode;
+  contentOnUnconnected?: React.ReactNode;
 };
-const Web3Provider = ({ children }: props) => {
+const Web3Provider = ({
+  children,
+  contentOnUnconnected = defaultContentOnUnconnected,
+}: props) => {
   const [web3Obj, setWeb3Obj] = useState<web3Context | null>(null);
 
   useEffect(() => {
@@ -61,7 +67,7 @@ const Web3Provider = ({ children }: props) => {
       {web3Obj ? (
         <web3Context.Provider value={web3Obj}>{children}</web3Context.Provider>
       ) : (
-        <div>metamaskに接続してください</div>
+        contentOnUnconnected
       )}
     </>
   );

--- a/client/src/components/organisms/providers/Web3Provider/index.tsx
+++ b/client/src/components/organisms/providers/Web3Provider/index.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import detectEthereumProvider from "@metamask/detect-provider";
@@ -62,15 +63,17 @@ const Web3Provider = ({
     connectMetamask();
   }, [connectMetamask]);
 
-  return (
-    <>
-      {web3Obj ? (
+  const content = useMemo(() => {
+    if (web3Obj) {
+      return (
         <web3Context.Provider value={web3Obj}>{children}</web3Context.Provider>
-      ) : (
-        contentOnUnconnected
-      )}
-    </>
-  );
+      );
+    } else {
+      return contentOnUnconnected;
+    }
+  }, [children, contentOnUnconnected, web3Obj]);
+
+  return <>{content}</>;
 };
 
 export default Web3Provider;

--- a/client/src/components/organisms/providers/Web3Provider/index.tsx
+++ b/client/src/components/organisms/providers/Web3Provider/index.tsx
@@ -77,6 +77,6 @@ const Web3Provider = ({
 };
 
 export default Web3Provider;
-export const useWeb3 = () => {
+export const useWeb3Context = () => {
   return useContext(web3Context);
 };

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -11,7 +11,7 @@ const EditArticlePage = () => {
   const [content, setContent] = useState("");
   const [title, setTitle] = useState("");
   const handleEditorChange = useCallback<
-    (a: string, editor: TinyMCEEditor) => void
+    (value: string, editor: TinyMCEEditor) => void
   >((value) => {
     setContent(value);
   }, []);
@@ -19,27 +19,37 @@ const EditArticlePage = () => {
 
   useEffect(() => {
     (async () => {
-      if (articleId) {
-        const { title, content } = await getArticle(articleId);
-        setTitle(title);
-        setContent(content);
+      try {
+        if (articleId) {
+          const { title, content } = await getArticle(articleId);
+          setTitle(title);
+          setContent(content);
+        }
+      } catch (error) {
+        console.error(error);
+        alert("記事の取得に失敗しました。");
       }
     })();
   }, [articleId]);
 
   const handleUpdate = useCallback(async () => {
-    const signature = await web3.eth.personal.sign(
-      "Update Article",
-      account,
-      ""
-    );
-    updateArticle({
-      articleId: articleId || "",
-      title,
-      content,
-      address: account,
-      signature,
-    });
+    try {
+      const signature = await web3.eth.personal.sign(
+        "Update Article",
+        account,
+        ""
+      );
+      await updateArticle({
+        articleId: articleId || "",
+        title,
+        content,
+        address: account,
+        signature,
+      });
+    } catch (error) {
+      console.error(error);
+      alert("記事の更新に失敗しました。");
+    }
   }, [account, articleId, content, title, web3.eth.personal]);
   return (
     <>

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -1,0 +1,65 @@
+import { useParams } from "react-router-dom";
+import { Editor } from "@tinymce/tinymce-react";
+import { Editor as TinyMCEEditor } from "tinymce";
+import { TINY_MCE_API_KEY } from "~/configs/tinymce";
+import { useCallback, useEffect, useState } from "react";
+import { getArticle, updateArticle } from "~/apis/knowtfolio";
+import { useWeb3 } from "~/components/organisms/Web3Provider";
+
+const EditArticlePage = () => {
+  const { articleId } = useParams();
+  const [content, setContent] = useState("");
+  const [title, setTitle] = useState("");
+  const handleEditorChange = useCallback<
+    (a: string, editor: TinyMCEEditor) => void
+  >((value) => {
+    setContent(value);
+  }, []);
+  const { web3, account } = useWeb3();
+
+  useEffect(() => {
+    (async () => {
+      if (articleId) {
+        const { title, content } = await getArticle(articleId);
+        setTitle(title);
+        setContent(content);
+      }
+    })();
+  }, [articleId]);
+
+  const handleUpdate = useCallback(async () => {
+    const signature = await web3.eth.personal.sign(
+      "Update Article",
+      account,
+      ""
+    );
+    updateArticle({
+      articleId: articleId || "",
+      title,
+      content,
+      address: account,
+      signature,
+    });
+  }, [account, articleId, content, title, web3.eth.personal]);
+  return (
+    <>
+      <h1>Edit Articles: {articleId}</h1>
+      <Editor
+        onEditorChange={handleEditorChange}
+        value={content}
+        apiKey={TINY_MCE_API_KEY}
+        init={{
+          height: 500,
+          menubar: true,
+          content_style:
+            "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
+        }}
+      />
+      <p>preview</p>
+      <div>{content}</div>
+      <button onClick={handleUpdate}>update article</button>
+    </>
+  );
+};
+
+export default EditArticlePage;

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -4,7 +4,7 @@ import { Editor as TinyMCEEditor } from "tinymce";
 import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useEffect, useState } from "react";
 import { getArticle, updateArticle } from "~/apis/knowtfolio";
-import { useWeb3 } from "~/components/organisms/providers/Web3Provider";
+import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 
 const EditArticlePage = () => {
   const { articleId } = useParams();
@@ -15,7 +15,7 @@ const EditArticlePage = () => {
   >((value) => {
     setContent(value);
   }, []);
-  const { web3, account } = useWeb3();
+  const { web3, account } = useWeb3Context();
 
   useEffect(() => {
     (async () => {

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -3,7 +3,7 @@ import { Editor } from "@tinymce/tinymce-react";
 import { Editor as TinyMCEEditor } from "tinymce";
 import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useEffect, useState } from "react";
-import { getArticle, updateArticle } from "~/apis/knowtfolio";
+import { getArticle, putArticle } from "~/apis/knowtfolio";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 
 const EditArticlePage = () => {
@@ -39,7 +39,7 @@ const EditArticlePage = () => {
         account,
         ""
       );
-      await updateArticle({
+      await putArticle({
         articleId: articleId || "",
         title,
         content,

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -4,7 +4,7 @@ import { Editor as TinyMCEEditor } from "tinymce";
 import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useEffect, useState } from "react";
 import { getArticle, updateArticle } from "~/apis/knowtfolio";
-import { useWeb3 } from "~/components/organisms/Web3Provider";
+import { useWeb3 } from "~/components/organisms/providers/Web3Provider";
 
 const EditArticlePage = () => {
   const { articleId } = useParams();

--- a/client/src/components/pages/EditArticlePage/index.tsx
+++ b/client/src/components/pages/EditArticlePage/index.tsx
@@ -53,7 +53,7 @@ const EditArticlePage = () => {
   }, [account, articleId, content, title, web3.eth.personal]);
   return (
     <>
-      <h1>Edit Articles: {articleId}</h1>
+      <h1>Edit Article: {articleId}</h1>
       <Editor
         onEditorChange={handleEditorChange}
         value={content}

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -37,7 +37,7 @@ const NewArticlePage = () => {
         content,
       });
       const signatureForMint = await web3.eth.personal.sign(
-        "MINT NFT",
+        "Mint NFT",
         account,
         ""
       );

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -1,0 +1,76 @@
+import { Editor } from "@tinymce/tinymce-react";
+import { Editor as TinyMCEEditor } from "tinymce";
+import { TINY_MCE_API_KEY } from "~/configs/tinymce";
+import { useCallback, useState } from "react";
+import { mintArticleNft, postArticle } from "~/apis/knowtfolio";
+import { useNavigate } from "react-router-dom";
+import { useWeb3 } from "~/components/organisms/Web3Provider";
+
+const NewArticlePage = () => {
+  const [content, setContent] = useState("");
+  const [titleInput, setTitleInput] = useState("");
+  const { web3, account } = useWeb3();
+  const handleEditorChange = useCallback<
+    (a: string, editor: TinyMCEEditor) => void
+  >((value) => {
+    setContent(value);
+  }, []);
+  const navigate = useNavigate();
+
+  const changeTitleInput = useCallback<
+    React.ChangeEventHandler<HTMLInputElement>
+  >((event) => {
+    setTitleInput(event.target.value);
+  }, []);
+
+  const handlePost = useCallback(async () => {
+    const signatureForCreate = await web3.eth.personal.sign(
+      "Create Article",
+      account,
+      ""
+    );
+    const { id } = await postArticle({
+      title: titleInput,
+      address: account,
+      signature: signatureForCreate,
+      content,
+    });
+    const signatureForMint = await web3.eth.personal.sign(
+      "MINT NFT",
+      account,
+      ""
+    );
+    await mintArticleNft({
+      articleId: id,
+      address: account,
+      signature: signatureForMint,
+    });
+    navigate(`/artcles/${id}`);
+  }, [account, content, navigate, titleInput, web3.eth.personal]);
+
+  return (
+    <>
+      <h1>New Aritcle</h1>
+      <p>
+        title:{" "}
+        <input type="text" onChange={changeTitleInput} value={titleInput} />
+      </p>
+      <Editor
+        onEditorChange={handleEditorChange}
+        value={content}
+        apiKey={TINY_MCE_API_KEY}
+        init={{
+          height: 500,
+          menubar: true,
+          content_style:
+            "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
+        }}
+      />
+      <p>preview</p>
+      <div>{content}</div>
+      <button onClick={handlePost}>create article</button>
+    </>
+  );
+};
+
+export default NewArticlePage;

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -4,12 +4,12 @@ import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useState } from "react";
 import { mintArticleNft, postArticle } from "~/apis/knowtfolio";
 import { useNavigate } from "react-router-dom";
-import { useWeb3 } from "~/components/organisms/providers/Web3Provider";
+import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 
 const NewArticlePage = () => {
   const [content, setContent] = useState("");
   const [titleInput, setTitleInput] = useState("");
-  const { web3, account } = useWeb3();
+  const { web3, account } = useWeb3Context();
   const handleEditorChange = useCallback<
     (value: string, editor: TinyMCEEditor) => void
   >((value) => {

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -11,7 +11,7 @@ const NewArticlePage = () => {
   const [titleInput, setTitleInput] = useState("");
   const { web3, account } = useWeb3();
   const handleEditorChange = useCallback<
-    (a: string, editor: TinyMCEEditor) => void
+    (value: string, editor: TinyMCEEditor) => void
   >((value) => {
     setContent(value);
   }, []);
@@ -24,28 +24,33 @@ const NewArticlePage = () => {
   }, []);
 
   const handlePost = useCallback(async () => {
-    const signatureForCreate = await web3.eth.personal.sign(
-      "Create Article",
-      account,
-      ""
-    );
-    const { id } = await postArticle({
-      title: titleInput,
-      address: account,
-      signature: signatureForCreate,
-      content,
-    });
-    const signatureForMint = await web3.eth.personal.sign(
-      "MINT NFT",
-      account,
-      ""
-    );
-    await mintArticleNft({
-      articleId: id,
-      address: account,
-      signature: signatureForMint,
-    });
-    navigate(`/artcles/${id}`);
+    try {
+      const signatureForCreate = await web3.eth.personal.sign(
+        "Create Article",
+        account,
+        ""
+      );
+      const { id } = await postArticle({
+        title: titleInput,
+        address: account,
+        signature: signatureForCreate,
+        content,
+      });
+      const signatureForMint = await web3.eth.personal.sign(
+        "MINT NFT",
+        account,
+        ""
+      );
+      await mintArticleNft({
+        articleId: id,
+        address: account,
+        signature: signatureForMint,
+      });
+      navigate(`/artcles/${id}`);
+    } catch (error) {
+      console.error(error);
+      alert("記事の作成に失敗しました。");
+    }
   }, [account, content, navigate, titleInput, web3.eth.personal]);
 
   return (

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -4,7 +4,7 @@ import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useState } from "react";
 import { mintArticleNft, postArticle } from "~/apis/knowtfolio";
 import { useNavigate } from "react-router-dom";
-import { useWeb3 } from "~/components/organisms/Web3Provider";
+import { useWeb3 } from "~/components/organisms/providers/Web3Provider";
 
 const NewArticlePage = () => {
   const [content, setContent] = useState("");

--- a/client/src/configs/tinymce.ts
+++ b/client/src/configs/tinymce.ts
@@ -1,0 +1,1 @@
+export const TINY_MCE_API_KEY = process.env.TINY_MCE_API_KEY || "";

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = {
     },
   },
   output: {
+    publicPath: "/",
     path: path.resolve(__dirname, "dist"), //バンドルしたファイルの出力先のパスを指定
     filename: "main.js", //出力時のファイル名の指定
   },


### PR DESCRIPTION
## 変更点
- Web3Providerを用意して、metamaskを使った認証を行い、metamaskアカウントを提供するProviderを実装した。
- NewArticlePageを実装した
- EditArticlePageを実装した
- webpackの設定を一箇所修正した
  - webpackの開発用のサーバーを立てるときに、rootのパスを設定した。
  - ↑をしないと、サイト内のパスがすべて相対パスになってしまい、たくさん`404`が発生してしまう