### PR TITLE
.PHONYのmakeターゲットでファイルを生成しないようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 GOA_DIR = server/gateways/api
 GOA_DESIGN_DIR = $(GOA_DIR)/design
 GOA_GEN_DIR = $(GOA_DIR)/gen
-GOA_DOCKER_FILE = ./server/goa.Dockerfile
+GOA_DOCKER_FILE = server/goa.Dockerfile
 
-HARDHAT_BUILD_DIRS = ./blockchain/artifacts ./blockchain/cache ./blockchain/typechain
+HARDHAT_BUILD_DIRS = blockchain/artifacts blockchain/cache blockchain/typechain
 
-CONTRACT_SOL_FILE = ./blockchain/contracts/Knowtfolio.sol
-CONTRACT_JSON_FILE = ./blockchain/artifacts/contracts/Knowtfolio.sol/Knowtfolio.json
+BLOCKCHAIN_NODE_MODULES_DIR = blockchain/node_modules
+
+CONTRACT_SOL_FILE = blockchain/contracts/Knowtfolio.sol
+CONTRACT_JSON_FILE = blockchain/artifacts/contracts/Knowtfolio.sol/Knowtfolio.json
 CONTRACT_ABI_FILE = $(CONTRACT_JSON_FILE:.json=.abi)
 
-GO_ETH_BINDING_RELATIVE_PATH = server/gateways/ethereum/contract_client.go
+GO_ETH_BINDING_PATH = server/gateways/ethereum/contract_client.go
 
-.PHONY: goa server go-eth-binding blockchain-node-modules
+.PHONY: goa server go-eth-binding
 
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker build -t knowtfolio/goa-gen -f $(GOA_DOCKER_FILE) ./server
@@ -19,24 +21,26 @@ $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 		/go/bin/goa gen github.com/team-azb/knowtfolio/$(GOA_DESIGN_DIR) \
 		-o /$(GOA_DIR)
 
-blockchain-node-modules: ./blockchain/package.json ./blockchain/Dockerfile
+$(BLOCKCHAIN_NODE_MODULES_DIR): ./blockchain/package.json ./blockchain/Dockerfile
 	docker build -t knowtfolio/hardhat ./blockchain
 	docker run -v `pwd`/blockchain:/work/blockchain knowtfolio/hardhat \
 	 	npm install --prefix ./blockchain
 
-$(CONTRACT_ABI_FILE): $(CONTRACT_SOL_FILE) blockchain-node-modules
+$(CONTRACT_ABI_FILE): $(CONTRACT_SOL_FILE) $(BLOCKCHAIN_NODE_MODULES_DIR)
 	docker build -t knowtfolio/hardhat ./blockchain
 	docker run -v `pwd`/blockchain:/work/blockchain knowtfolio/hardhat \
 		npm run --prefix ./blockchain build
 	# Extract abi field from `$(CONTRACT_JSON_FILE)`.
 	cat $(CONTRACT_JSON_FILE) | jq '.abi' > $(CONTRACT_ABI_FILE)
 
-go-eth-binding: $(CONTRACT_ABI_FILE)
+$(GO_ETH_BINDING_PATH): $(CONTRACT_ABI_FILE)
 	docker run -v `pwd`/blockchain:/blockchain \
 		-v `pwd`/server:/server \
 		ethereum/client-go:alltools-v1.10.20 \
 		abigen --abi $(CONTRACT_ABI_FILE) --pkg ethereum \
-			--type ContractClient --out /$(GO_ETH_BINDING_RELATIVE_PATH)
+			--type ContractClient --out /$(GO_ETH_BINDING_PATH)
+
+go-eth-binding: $(GO_ETH_BINDING_PATH)
 
 goa: $(GOA_GEN_DIR)
 
@@ -44,4 +48,4 @@ server: goa go-eth-binding
 	docker-compose up --build server
 
 clean:
-	rm -rf $(GOA_GEN_DIR) $(HARDHAT_BUILD_DIRS) ./$(GO_ETH_BINDING_RELATIVE_PATH)
+	rm -rf $(GOA_GEN_DIR) $(HARDHAT_BUILD_DIRS) $(GO_ETH_BINDING_PATH) $(BLOCKCHAIN_NODE_MODULES_DIR)


### PR DESCRIPTION
本来Makefileのtargetは、依存関係に変更があったときのみ実行されるが、依存に.PHONYのtargetが入っていると、そいつは常に変更されてる判定になって必ずその.PHONYも実行されてしまう

なので、今まで`make server`をすると、`blockchain-node-modules`が必ず変更された判定になるので、それ以降の全て（`blockchain-node-modules`, `$(CONTRACT_ABI_FILE)`, `go-eth-binding`）が毎回実行されて、サーバの起動が毎回面倒だった

今回、`blockchain-node-modules`をファイル名に変え、`go-eth-binding`でもコマンドを実行するのをやめた（真下のファイル名のターゲットで処理を実行するようにした）