### PR TITLE
Contractのメソッド追加とリファクタ

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ make clean
 
 ## Smart Contracts
 * prod: https://mumbai.polygonscan.com/address/0xCd9554e90FCdC339F41F775c25b0EE00Add2b2ba
-* dev: https://mumbai.polygonscan.com/address/0xf96D4c65dcBDf94dAc757128eF9Ed31b8d3D7Cc9
+* dev: https://mumbai.polygonscan.com/address/0x1c63329065425B9FE585b14F48E6037795f52443

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ make clean
 * [Hardhat](https://hardhat.org): Contract Compilation
 
 ## Smart Contracts
-* https://mumbai.polygonscan.com/address/0xCd9554e90FCdC339F41F775c25b0EE00Add2b2ba
-
+* prod: https://mumbai.polygonscan.com/address/0xCd9554e90FCdC339F41F775c25b0EE00Add2b2ba
+* dev: https://mumbai.polygonscan.com/address/0xf96D4c65dcBDf94dAc757128eF9Ed31b8d3D7Cc9

--- a/blockchain/contracts/ERC721URIStorageEnumerableUpgradeable.sol
+++ b/blockchain/contracts/ERC721URIStorageEnumerableUpgradeable.sol
@@ -7,7 +7,10 @@ import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URISto
 /**
  * @dev Abstract contract to resolve function conflicts due to diamond inheritance.
  */
-abstract contract ERC721URIStorageEnumerableUpgradeable is ERC721URIStorageUpgradeable, ERC721EnumerableUpgradeable {
+abstract contract ERC721URIStorageEnumerableUpgradeable is
+    ERC721URIStorageUpgradeable,
+    ERC721EnumerableUpgradeable
+{
     function _beforeTokenTransfer(
         address from,
         address to,

--- a/blockchain/contracts/ERC721URIStorageEnumerableUpgradeable.sol
+++ b/blockchain/contracts/ERC721URIStorageEnumerableUpgradeable.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+
+/**
+ * @dev Abstract contract to resolve function conflicts due to diamond inheritance.
+ */
+abstract contract ERC721URIStorageEnumerableUpgradeable is ERC721URIStorageUpgradeable, ERC721EnumerableUpgradeable {
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    )
+        internal
+        virtual
+        override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
+    {
+        ERC721EnumerableUpgradeable._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    function _burn(uint256 tokenId)
+        internal
+        virtual
+        override(ERC721Upgradeable, ERC721URIStorageUpgradeable)
+    {
+        ERC721URIStorageUpgradeable._burn(tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
+        returns (bool)
+    {
+        return ERC721EnumerableUpgradeable.supportsInterface(interfaceId);
+    }
+
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override(ERC721Upgradeable, ERC721URIStorageUpgradeable)
+        returns (string memory)
+    {
+        return ERC721URIStorageUpgradeable.tokenURI(tokenId);
+    }
+}

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -19,9 +19,16 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageUpgradeable {
         __ERC721URIStorage_init();
     }
 
+    /**
+     * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
+     * token will be the concatenation of the `baseURI` and the `tokenId`.
+     */
+    function _baseURI() internal view virtual override(ERC721Upgradeable) returns (string memory) {
+        return "https://knowtfolio.com/articles/";
+    }
+
     function mintNFT(
         address recipient,
-        string memory _tokenURI,
         string memory _articleId
     ) public onlyOwner returns (uint256) {
         require(bytes(_articleId).length > 0 && tokenIdOf[_articleId] == 0);
@@ -29,7 +36,7 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageUpgradeable {
 
         uint256 newItemId = _tokenIds.current();
         _mint(recipient, newItemId);
-        _setTokenURI(newItemId, _tokenURI);
+        _setTokenURI(newItemId, _articleId);
         tokenIdOf[_articleId] = newItemId;
 
         return newItemId;

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -62,10 +62,10 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable
     /**
      * @dev Collects all article ids that is owned by `user`.
      */
-    function getArticlesOwnedBy(address user)
-    public
-    view
-    returns (string[] memory)
+    function getArticleIdsOwnedBy(address user)
+        public
+        view
+        returns (string[] memory)
     {
         uint256 numberOfTokens = balanceOf(user);
         string[] memory articleIds = new string[](numberOfTokens);

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -35,7 +35,7 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable
         _tokenIds.increment();
 
         uint256 newItemId = _tokenIds.current();
-        _mint(recipient, newItemId);
+        _safeMint(recipient, newItemId);
         _setTokenURI(newItemId, _articleId);
         tokenIdOf[_articleId] = newItemId;
 

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -5,9 +5,9 @@ import "hardhat/console.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
+import "./ERC721URIStorageEnumerableUpgradeable.sol";
 
-contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageUpgradeable {
+contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable {
     using CountersUpgradeable for CountersUpgradeable.Counter;
     CountersUpgradeable.Counter internal _tokenIds;
 
@@ -57,5 +57,22 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageUpgradeable {
         } else {
             return ownerOf(_tokenId);
         }
+    }
+
+    /**
+     * @dev Collects all article ids that is owned by `user`.
+     */
+    function getArticlesOwnedBy(address user)
+    public
+    view
+    returns (string[] memory)
+    {
+        uint256 numberOfTokens = balanceOf(user);
+        string[] memory articleIds = new string[](numberOfTokens);
+        for (uint256 index = 0; index < numberOfTokens; index++) {
+            uint256 token = tokenOfOwnerByIndex(user, index);
+            articleIds[index] = tokenURI(token);
+        }
+        return articleIds;
     }
 }

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -7,7 +7,10 @@ import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./ERC721URIStorageEnumerableUpgradeable.sol";
 
-contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable {
+contract Knowtfolio is
+    OwnableUpgradeable,
+    ERC721URIStorageEnumerableUpgradeable
+{
     using CountersUpgradeable for CountersUpgradeable.Counter;
     CountersUpgradeable.Counter internal _tokenIds;
 
@@ -23,14 +26,21 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable
      * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
      * token will be the concatenation of the `baseURI` and the `tokenId`.
      */
-    function _baseURI() internal view virtual override(ERC721Upgradeable) returns (string memory) {
+    function _baseURI()
+        internal
+        view
+        virtual
+        override(ERC721Upgradeable)
+        returns (string memory)
+    {
         return "https://knowtfolio.com/articles/";
     }
 
-    function mintNFT(
-        address recipient,
-        string memory _articleId
-    ) public onlyOwner returns (uint256) {
+    function mintNFT(address recipient, string memory _articleId)
+        public
+        onlyOwner
+        returns (uint256)
+    {
         require(bytes(_articleId).length > 0 && tokenIdOf[_articleId] == 0);
         _tokenIds.increment();
 

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -14,7 +14,7 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageEnumerableUpgradeable
     mapping(string => uint256) internal tokenIdOf;
 
     function initialize() public initializer {
-        __ERC721_init("Knowtfolio", "PON");
+        __ERC721_init("Knowtfolio", "FOLIO");
         __Ownable_init();
         __ERC721URIStorage_init();
     }

--- a/blockchain/contracts/Knowtfolio.sol
+++ b/blockchain/contracts/Knowtfolio.sol
@@ -42,17 +42,20 @@ contract Knowtfolio is OwnableUpgradeable, ERC721URIStorageUpgradeable {
         return newItemId;
     }
 
-    function isOwnerOfArticle(address editor, string memory articleId)
+    /**
+     * @dev Get owner of the Article NFT of `articleId`.
+     * If there's no NFT for `articleId`, the function returns an empty address.
+     */
+    function getOwnerOfArticle(string memory articleId)
         public
         view
-        onlyOwner
-        returns (bool)
+        returns (address)
     {
         uint256 _tokenId = tokenIdOf[articleId];
         if (_tokenId == 0) {
-            return false;
+            return address(0);
+        } else {
+            return ownerOf(_tokenId);
         }
-        address owner = ownerOf(_tokenId);
-        return owner == editor;
     }
 }

--- a/server/services/nfts.go
+++ b/server/services/nfts.go
@@ -57,7 +57,6 @@ func (s nftsService) CreateForArticle(_ context.Context, request *nfts.CreateNft
 	tx, err := s.Contract.MintNFT(
 		opts,
 		common.HexToAddress(request.Address),
-		fmt.Sprintf("https://knowtfolio.xyz/articles/%v", target.ID),
 		target.ID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Closes #42 

* `isOwnerOfArticle`を`getOwnerOfArticle`にして汎用性を少し上げた
  * これにより、NFTがない場合は`0x00000...`を返せるようになったので、DELETEでNFTができた後は`OriginalAuthorAddress`をチェックする必要がなくなった
* 検索用エンドポイントを見越して`getArticlesOwnedBy`を追加: #42 
* `mintNFT`のリファクタ
  * `_mint`の代わりに`_safeMint`を使うように
  * `baseURI`をオーバーライドすることで、引数のURIを不要とした
* ダイヤモンド継承対策
  * `ERC721URIStorageEnumerableUpgradeable`を追加することで、関数のコンフリクトを解消するためのオーバーライドを、別のファイルに逃した