### PR TITLE
Goaファイルの生成も、non-rootユーザで行うように

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,14 @@ CONTRACT_BIN_FILE = $(CONTRACT_JSON_FILE:.json=.bin)
 
 GO_ETH_BINDING_PATH = server/gateways/ethereum/binding.go
 
-ENTRYPOINT_OPTS = -e HOST_UID=`id -u ${USER}` -e HOST_GID=`id -g ${USER}`
+ENTRYPOINT_OPTS = --entrypoint "/entrypoint.sh" \
+	-v `pwd`/entrypoint.sh:/entrypoint.sh \
+	-e HOST_UID=`id -u ${USER}` \
+	-e HOST_GID=`id -g ${USER}`
 
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker build -t knowtfolio/goa-gen -f $(GOA_DOCKER_FILE) ./server
 	docker run $(ENTRYPOINT_OPTS) \
-		-v `pwd`/entrypoint.sh:/server/entrypoint.sh \
 		-v `pwd`/$(GOA_DIR):/$(GOA_DIR) \
 		knowtfolio/goa-gen \
 		/server/go/bin/goa gen github.com/team-azb/knowtfolio/$(GOA_DESIGN_DIR) \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 		-v `pwd`/entrypoint.sh:/server/entrypoint.sh \
 		-v `pwd`/$(GOA_DIR):/$(GOA_DIR) \
 		knowtfolio/goa-gen \
-		/go/bin/goa gen github.com/team-azb/knowtfolio/$(GOA_DESIGN_DIR) \
+		/server/go/bin/goa gen github.com/team-azb/knowtfolio/$(GOA_DESIGN_DIR) \
 		-o /$(GOA_DIR)
 
 $(BLOCKCHAIN_NODE_MODULES_DIR): ./blockchain/package.json ./blockchain/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ ENTRYPOINT_OPTS = --entrypoint "/entrypoint.sh" \
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker build -t knowtfolio/goa-gen -f $(GOA_DOCKER_FILE) ./server
 	docker run $(ENTRYPOINT_OPTS) \
+		-e CHOWN_WORKDIR=1 \
 		-v `pwd`/$(GOA_DIR):/$(GOA_DIR) \
 		knowtfolio/goa-gen \
 		/server/go/bin/goa gen github.com/team-azb/knowtfolio/$(GOA_DESIGN_DIR) \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
       dockerfile: blockchain/Dockerfile
     ports:
       - "8545:8545"
-    entrypoint: ./entrypoint.sh
     command: npm --prefix ./blockchain run node
     volumes:
       - type: bind
@@ -60,7 +59,3 @@ services:
       - type: bind
         source: ./server
         target: /work/server
-      - type: bind
-        source: ./entrypoint.sh
-        target: /work/entrypoint.sh
-        read_only: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,10 @@ groupadd -g $HOST_GID -o knowtfolio
 useradd -u $HOST_UID -g $HOST_GID -o -m knowtfolio
 export HOME=/home/knowtfolio
 
-chown -R knowtfolio .
+# Since chown takes some time if the target dir is big,
+# this is an option.
+if [[ $CHOWN_WORKDIR ]]; then
+  echo "chowning all files in WORKDIR"
+  chown -R knowtfolio .
+fi
 exec /usr/sbin/gosu knowtfolio "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,7 @@
 # will be owned by the host user (not the root user).
 # Ref: https://qiita.com/yohm/items/047b2e68d008ebb0f001
 
+groupadd -g $HOST_GID -o knowtfolio
 useradd -u $HOST_UID -g $HOST_GID -o -m knowtfolio
 export HOME=/home/knowtfolio
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,4 +7,5 @@
 useradd -u $HOST_UID -g $HOST_GID -o -m knowtfolio
 export HOME=/home/knowtfolio
 
+chown -R knowtfolio .
 exec /usr/sbin/gosu knowtfolio "$@"

--- a/server/goa.Dockerfile
+++ b/server/goa.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /server
 
 # Putting GOPATH under the WORKDIR makes entrypoint.sh `chown` the binaries,
 # and that makes the binaries will be accessible from non-root user.
-ARG GOPATH=/server/go
+ENV GOPATH=/server/go
 
 RUN apt-get update && \
     # Necessary packages for entrypoint.sh

--- a/server/goa.Dockerfile
+++ b/server/goa.Dockerfile
@@ -2,7 +2,9 @@ FROM golang:1.18.3
 
 WORKDIR /server
 
-ARG GOPATH=/go
+# Putting GOPATH under the WORKDIR makes entrypoint.sh `chown` the binaries,
+# and that makes the binaries will be accessible from non-root user.
+ARG GOPATH=/server/go
 
 RUN apt-get update && \
     # Necessary packages for entrypoint.sh

--- a/server/goa.Dockerfile
+++ b/server/goa.Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18.3
 WORKDIR /server
 
 # Putting GOPATH under the WORKDIR makes entrypoint.sh `chown` the binaries,
-# and that makes the binaries will be accessible from non-root user.
+# and that makes the binaries accessible from non-root user.
 ENV GOPATH=/server/go
 
 RUN apt-get update && \


### PR DESCRIPTION
#52 の積み残し

* Makefile側で`--entrypoint`を使って指定するようにした（これを忘れていたのでrootで作られたままだった）
* entrypoint.shで、`chown`を使って、WORKDIRの所有権をnon-rootユーザに移すようにした
* ↑を利用して、`goa.Dockerfile`での`go install`の結果がWORKDIRである`/server`以下に入るよう、`GOPATH=/server/go`とした
  * これをしないと、↑で`--entrypoint`を指定してもpermission deniedとなってしまう。