### PR TITLE
`GET /api/articles/:id`で所有者のアドレスを返すように

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ server: goa go-eth-binding
 	docker-compose up --build server
 
 test: goa go-eth-binding
+	HOST_UID=`id -u ${USER}` HOST_GID=`id -g ${USER}` \
 	docker-compose up --build test
 
 clean:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     build: server
     command: bash -c "
       /scripts/wait-for-it.sh db:3306 --timeout=60 --strict &&
+      /scripts/wait-for-it.sh hardhat:8545 --timeout=60 --strict &&
       go test ./models/... ./services/..."
     environment:
       ADMIN_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
@@ -51,6 +52,10 @@ services:
       dockerfile: blockchain/Dockerfile
     ports:
       - "8545:8545"
+    environment:
+      HOST_UID: ${HOST_UID}
+      HOST_GID: ${HOST_GID}
+    entrypoint: /entrypoint.sh
     command: npm --prefix ./blockchain run node
     volumes:
       - type: bind
@@ -59,3 +64,6 @@ services:
       - type: bind
         source: ./server
         target: /work/server
+      - type: bind
+        source: ./entrypoint.sh
+        target: /entrypoint.sh

--- a/server/gateways/api/design/article.go
+++ b/server/gateways/api/design/article.go
@@ -57,21 +57,32 @@ var articleDeleteRequest = dsl.Type("ArticleDeleteRequest", func() {
 	dsl.Required("id", "address", "signature")
 })
 
-var article = dsl.Type("Article", func() {
-	articleIdAttribute("id")
-	articleTitleAttribute("title")
-	articleContentAttribute("content")
-	dsl.Required("id", "title", "content")
-})
-
 var articleResult = dsl.ResultType("article-result", "ArticleResult", func() {
-	dsl.Extend(article)
+	dsl.Attributes(func() {
+		articleIdAttribute("id")
+		articleTitleAttribute("title")
+		articleContentAttribute("content")
+		dsl.Attribute("owner_address", dsl.String, func() {
+			dsl.Description("所有者のウォレットのアドレス")
+			dsl.Pattern("^0x[a-fA-F0-9]{40}$")
+			dsl.Example(`0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 `)
+		})
+		dsl.Required("id", "title", "content", "owner_address")
+	})
 
 	dsl.View("default", func() {
 		dsl.Attribute("id")
 		dsl.Attribute("title")
 		dsl.Attribute("content")
 	})
+
+	dsl.View("with-owner-address", func() {
+		dsl.Attribute("id")
+		dsl.Attribute("title")
+		dsl.Attribute("content")
+		dsl.Attribute("owner_address")
+	})
+
 	dsl.View("only-id", func() {
 		dsl.Attribute("id")
 	})
@@ -109,7 +120,7 @@ var _ = dsl.Service("articles", func() {
 		dsl.Payload(articleReadRequest)
 
 		dsl.Result(articleResult, func() {
-			dsl.View("default")
+			dsl.View("with-owner-address")
 		})
 
 		dsl.HTTP(func() {

--- a/server/gateways/api/gen/http/openapi3.yaml
+++ b/server/gateways/api/gen/http/openapi3.yaml
@@ -128,10 +128,11 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/CreateResponseBody'
+                                $ref: '#/components/schemas/ReadResponseBodyWithOwnerAddress'
                             example:
                                 content: <h1> Hello World! </h1>
                                 id: exampleId01
+                                owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
                                 title: My Awesome Article
                 "404":
                     description: 'article_not_found: 記事IDに対応する記事が見つからなかった場合'
@@ -438,6 +439,39 @@ components:
                 - temporary
                 - timeout
                 - fault
+        ReadResponseBodyWithOwnerAddress:
+            type: object
+            properties:
+                content:
+                    type: string
+                    description: 本文のHTML
+                    example: <h1> Hello World! </h1>
+                id:
+                    type: string
+                    description: 記事のID
+                    example: exampleId01
+                    pattern: ^[A-Za-z0-9_-]+$
+                    minLength: 11
+                    maxLength: 11
+                owner_address:
+                    type: string
+                    description: 所有者のウォレットのアドレス
+                    example: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                    pattern: ^0x[a-fA-F0-9]{40}$
+                title:
+                    type: string
+                    example: My Awesome Article
+            description: ReadResponseBody result type (with-owner-address view)
+            example:
+                content: <h1> Hello World! </h1>
+                id: exampleId01
+                owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                title: My Awesome Article
+            required:
+                - id
+                - title
+                - content
+                - owner_address
         UpdateRequestBody:
             type: object
             properties:

--- a/server/services/articles.go
+++ b/server/services/articles.go
@@ -166,9 +166,9 @@ func articleIdToResult(src string) *articles.ArticleResult {
 	})
 }
 
-func articleWithOwnerAddressToResult(src models.Article, ownerAddress common.Address) *articles.ArticleResult {
+func articleWithOwnerAddressToResult(src models.Article, owner common.Address) *articles.ArticleResult {
 	contentStr := string(src.Content)
-	ownerAddressStr := ownerAddress.String()
+	ownerAddressStr := owner.String()
 	return articles.NewArticleResult(&articlesviews.ArticleResult{
 		Projected: &articlesviews.ArticleResultView{
 			ID:           &src.ID,


### PR DESCRIPTION
Closes #45 

今回は小規模な変更なので、designと実装をまとめてやった
また、テストコンテナが機能しない状態になっていたので、docker-compose.ymlとMakefileを少し修正した（積み残し→ #55 ）

現状、Contractの`GetOwnerOfArticle`から0アドレスが返ってきた場合、NFTが存在しないと判断しているが、厳密にはこれだと0x00アドレスの人がサービスを利用できない（使う確率はがどれくらいあるのかわからんが）ので、優先度は低いがissueを立てた： #56 