### PR TITLE
nftのメタデータ作成用のawsリソース作成

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -10,6 +10,6 @@ resource "aws_iam_user_policy" "knowtfolio_nft_io" {
   name = "knowtfolio-nft-io"
   user = aws_iam_user.knowtfolio_admin.name
   policy = templatefile("${path.module}/templates/iam/s3_io_iam_policy.json", {
-    resource = "${aws_s3_bucket.knowtfolio_alpha.arn}/nfts/*"
+    resource = "${aws_s3_bucket.knowtfolio_resources.arn}/nfts/*"
   })
 }

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -1,0 +1,15 @@
+resource "aws_iam_user" "knowtfolio_admin" {
+  name = "knowtfolio_admin"
+}
+
+resource "aws_iam_access_key" "knowtfolio_admin" {
+  user = aws_iam_user.knowtfolio_admin.name
+}
+
+resource "aws_iam_user_policy" "knowtfolio_nft_io" {
+  name = "knowtfolio-nft-io"
+  user = aws_iam_user.knowtfolio_admin.name
+  policy = templatefile("${path.module}/templates/iam/s3_io_iam_policy.json", {
+    resource = "${aws_s3_bucket.knowtfolio_alpha.arn}/nfts/*"
+  })
+}

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -29,3 +29,35 @@ resource "aws_s3_bucket_policy" "knowtfolio" {
     identifier = aws_cloudfront_origin_access_identity.knowtfolio.iam_arn
   })
 }
+
+resource "aws_s3_bucket" "knowtfolio_alpha" {
+  bucket = "knowtfolio-alpha"
+}
+
+resource "aws_s3_bucket_versioning" "knowtfolio_alpha" {
+  bucket = aws_s3_bucket.knowtfolio_alpha.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "knowtfolio_alpha" {
+  bucket = aws_s3_bucket.knowtfolio_alpha.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "knowtfolio_alpha" {
+  bucket                  = aws_s3_bucket.knowtfolio_alpha.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "knowtfolio_alpha" {
+  bucket = aws_s3_bucket.knowtfolio_alpha.id
+  policy = templatefile("${path.module}/templates/s3/hosting_bucket_policy.json", {
+    bucket     = aws_s3_bucket.knowtfolio_alpha.bucket
+    identifier = aws_cloudfront_origin_access_identity.knowtfolio.iam_arn
+  })
+}

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -30,34 +30,34 @@ resource "aws_s3_bucket_policy" "knowtfolio" {
   })
 }
 
-resource "aws_s3_bucket" "knowtfolio_alpha" {
-  bucket = "dev-knowtfolio-alpha"
+resource "aws_s3_bucket" "knowtfolio_resources" {
+  bucket = "dev-knowtfolio-resources"
 }
 
-resource "aws_s3_bucket_versioning" "knowtfolio_alpha" {
-  bucket = aws_s3_bucket.knowtfolio_alpha.id
+resource "aws_s3_bucket_versioning" "knowtfolio_resources" {
+  bucket = aws_s3_bucket.knowtfolio_resources.id
   versioning_configuration {
     status = "Enabled"
   }
 }
 
-resource "aws_s3_bucket_acl" "knowtfolio_alpha" {
-  bucket = aws_s3_bucket.knowtfolio_alpha.id
+resource "aws_s3_bucket_acl" "knowtfolio_resources" {
+  bucket = aws_s3_bucket.knowtfolio_resources.id
   acl    = "private"
 }
 
-resource "aws_s3_bucket_public_access_block" "knowtfolio_alpha" {
-  bucket                  = aws_s3_bucket.knowtfolio_alpha.id
+resource "aws_s3_bucket_public_access_block" "knowtfolio_resources" {
+  bucket                  = aws_s3_bucket.knowtfolio_resources.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_policy" "knowtfolio_alpha" {
-  bucket = aws_s3_bucket.knowtfolio_alpha.id
+resource "aws_s3_bucket_policy" "knowtfolio_resources" {
+  bucket = aws_s3_bucket.knowtfolio_resources.id
   policy = templatefile("${path.module}/templates/s3/hosting_bucket_policy.json", {
-    bucket     = aws_s3_bucket.knowtfolio_alpha.bucket
+    bucket     = aws_s3_bucket.knowtfolio_resources.bucket
     identifier = aws_cloudfront_origin_access_identity.knowtfolio.iam_arn
   })
 }

--- a/infrastructure/s3.tf
+++ b/infrastructure/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "knowtfolio" {
-  bucket = "knowtfolio"
+  bucket = "dev-knowtfolio"
 }
 
 resource "aws_s3_bucket_versioning" "knowtfolio" {
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_policy" "knowtfolio" {
 }
 
 resource "aws_s3_bucket" "knowtfolio_alpha" {
-  bucket = "knowtfolio-alpha"
+  bucket = "dev-knowtfolio-alpha"
 }
 
 resource "aws_s3_bucket_versioning" "knowtfolio_alpha" {

--- a/infrastructure/templates/iam/s3_io_iam_policy.json
+++ b/infrastructure/templates/iam/s3_io_iam_policy.json
@@ -1,0 +1,15 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1657696966841",
+            "Action": [
+                "s3:DeleteObject",
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Effect": "Allow",
+            "Resource": "${resource}"
+        }
+    ]
+}


### PR DESCRIPTION
以下のリソースを用意した
- `knowtfolio-alpha`というs3 bucket
  - cloudfrontからgetが出来るという設定もついている（この点はknowtfolioという名前のs3 bucketと同じ仕様）
- ↑のbucketの`/nfts/`階層のCRUDを行う権限を持つiam user