### PR TITLE
バックエンドテストでtransactionのnonceのエラーを解消

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,10 @@ services:
     command: bash -c "
       /scripts/wait-for-it.sh db:3306 --timeout=60 --strict &&
       /scripts/wait-for-it.sh hardhat:8545 --timeout=60 --strict &&
-      go test ./models/... ./services/..."
+      go test -count=1 ./models/... ./services/..."
     environment:
-      ADMIN_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+      # Account#2 of hardhat local node.
+      ADMIN_PRIVATE_KEY: 5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
       CONTRACT_ADDRESS: will-be-set-in-the-program
       NETWORK_URI: http://hardhat:8545
       CHAIN_ID: 31337
@@ -67,3 +68,39 @@ services:
       - type: bind
         source: ./entrypoint.sh
         target: /entrypoint.sh
+
+  goa:
+    build:
+      context: server
+      dockerfile: goa.Dockerfile
+    entrypoint: /entrypoint.sh
+    command: [
+        "/server/go/bin/goa", "gen",
+        "github.com/team-azb/knowtfolio/${GOA_DESIGN_DIR}",
+        "-o", "/${GOA_DIR}"
+    ]
+    environment:
+      CHOWN_WORKDIR: 1
+      HOST_UID: ${HOST_UID}
+      HOST_GID: ${HOST_GID}
+    volumes:
+      - type: bind
+        source: ./server/gateways/api
+        target: /server/gateways/api
+      - type: bind
+        source: ./entrypoint.sh
+        target: /entrypoint.sh
+
+  go-eth-binding:
+    image: ethereum/client-go:alltools-v1.10.20
+    command: [
+        "abigen", "--abi", "${CONTRACT_ABI_FILE}", "--bin", "${CONTRACT_BIN_FILE}",
+        "--pkg", "ethereum", "--type", "ContractBinding", "--out", "${GO_ETH_BINDING_PATH}"
+    ]
+    volumes:
+      - type: bind
+        source: ./blockchain
+        target: /blockchain
+      - type: bind
+        source: ./server
+        target: /server

--- a/server/goa.Dockerfile
+++ b/server/goa.Dockerfile
@@ -12,4 +12,4 @@ RUN apt-get update && \
 
 RUN go install goa.design/goa/v3/cmd/goa@v3
 
-COPY go.mod /server/
+COPY go.mod go.sum /server/

--- a/server/services/articles_test.go
+++ b/server/services/articles_test.go
@@ -223,6 +223,10 @@ func mintNFTOfArticle0AndWait(t *testing.T, cli *ethereum.ContractClient, ownerA
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	transactionLock[opts.From.String()].Lock()
+	defer transactionLock[opts.From.String()].Unlock()
+
 	tx, err := cli.MintNFT(opts, common.HexToAddress(ownerAddr), article0.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/server/services/init_test.go
+++ b/server/services/init_test.go
@@ -13,16 +13,19 @@ import (
 	"testing"
 )
 
-func skipfIfError(t *testing.T, err error, format string, args ...any) {
+func fatalfIfError(t *testing.T, err error, format string, args ...any) {
 	if err != nil {
-		t.Skipf("%v: %v", fmt.Sprintf(format, args...), err)
+		t.Fatalf("%v: %v", fmt.Sprintf(format, args...), err)
 	}
 }
 
 func initTestDB(t *testing.T) (db *gorm.DB) {
+	if testing.Short() {
+		t.Skip("Tests using DB are skipped.")
+	}
 	// Connect to DB.
 	db, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/?parseTime=true"))
-	skipfIfError(t, err, "DB Connection failed")
+	fatalfIfError(t, err, "DB Connection failed")
 
 	// Create temporary database dedicated to this test call.
 	dbName := fmt.Sprintf("knowtfolio-db-test-%v", strings.ReplaceAll(t.Name(), "/", "_"))
@@ -40,25 +43,29 @@ func initTestDB(t *testing.T) (db *gorm.DB) {
 
 	// Connect to the temporary database.
 	db, err = gorm.Open(mysql.Open(fmt.Sprintf("root:password@tcp(db:3306)/%v?parseTime=true", dbName)))
-	skipfIfError(t, err, "Connection to Created DB %v failed", dbName)
+	fatalfIfError(t, err, "Connection to Created DB %v failed", dbName)
 
 	return
 }
 
 func initTestContractClient(t *testing.T) *ethereum.ContractClient {
+	if testing.Short() {
+		t.Skip("Tests using Contract are skipped.")
+	}
+
 	client, err := ethclient.Dial(config.NetworkURI)
-	skipfIfError(t, err, "EthClient Connection failed")
+	fatalfIfError(t, err, "EthClient Connection failed")
 
 	// Initialize transactor to deploy the contract.
 	opts, err := bind.NewKeyedTransactorWithChainID(config.AdminPrivateKey, config.ChainID)
 	opts.GasPrice, err = client.SuggestGasPrice(opts.Context)
-	skipfIfError(t, err, "Failed to init transactor")
+	fatalfIfError(t, err, "Failed to init transactor")
 
 	// Deploy the contract and wait for it to complete.
 	_, tx, _, err := ethereum.DeployContractBinding(opts, client)
-	skipfIfError(t, err, "Contract deployment failed")
+	fatalfIfError(t, err, "Contract deployment failed")
 	addr, err := bind.WaitDeployed(context.Background(), client, tx)
-	skipfIfError(t, err, "Contract deployment waiting failed")
+	fatalfIfError(t, err, "Contract deployment waiting failed")
 
 	// Initialize the client and the contract.
 	config.ContractAddress = addr
@@ -67,7 +74,7 @@ func initTestContractClient(t *testing.T) *ethereum.ContractClient {
 	//       and, as a result, the owner of the contract becomes 0x0, which makes onlyOwner calls impossible.
 	//       Therefore, we call `initialize` explicitly here in order to the owner to admin.
 	_, _ = cli.Initialize(opts)
-	skipfIfError(t, err, "Contract initialization failed")
+	fatalfIfError(t, err, "Contract initialization failed")
 
 	t.Logf("[%v] Deployed contract %v to %v!", t.Name(), config.ContractAddress, config.NetworkURI)
 

--- a/server/services/nfts_test.go
+++ b/server/services/nfts_test.go
@@ -38,11 +38,13 @@ func TestCreateNFTForArticle(t *testing.T) {
 
 	service.DB.Create(&article0)
 
+	transactionLock[user0Addr].Lock()
 	result, err := service.CreateForArticle(context.Background(), &nfts.CreateNftForArticleRequest{
 		ArticleID: article0.ID,
 		Address:   user0Addr,
 		Signature: user0MintNFTSign,
 	})
+	transactionLock[user0Addr].Unlock()
 	assert.NoError(t, err)
 
 	// Assert NFT existence.


### PR DESCRIPTION
Closes #55 

* DBやhardhatへの疎通が失敗した時に、Skipするのではなく、Fatalを吐く仕様にし、これらの疎通をしたくない状況では`go test`コマンドのオプションで`-short`を指定すればskipされるようにした
* `sync.Mutex`をアドレスごとに管理し、同じアドレスによるトランザクションが同時並行で発生しないようにした
  * これが発生すると、トランザクションに入る`nonce`に不整合が生じ、これによりエラーが発生していた
* goaとgo-eth-bindingをdocker-composeに追加し、Makefileをスッキリさせつつ、`run hardhat`で出ていたエラーを解消