### PR TITLE
ヘルスチェックエンドポイントの追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       # Account#2 of hardhat local node.
       ADMIN_PRIVATE_KEY: 5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a
       CONTRACT_ADDRESS: will-be-set-in-the-program
-      NETWORK_URI: http://hardhat:8545
+      NETWORK_URI: ws://hardhat:8545
       CHAIN_ID: 31337
     volumes:
       - type: bind

--- a/server/gateways/api/design/healthcheck.go
+++ b/server/gateways/api/design/healthcheck.go
@@ -1,0 +1,32 @@
+package design
+
+import "goa.design/goa/v3/dsl"
+
+var _ = dsl.Service("healthcheck", func() {
+	dsl.Description("疎通確認サービス")
+
+	dsl.Error("database_unhealthy")
+	dsl.Error("contract_unhealthy")
+
+	dsl.HTTP(func() {
+		dsl.Path("/health")
+		dsl.Response("database_unhealthy", dsl.StatusInternalServerError, func() {
+			dsl.Description("サーバは生きているが、DBと接続できない場合")
+		})
+		dsl.Response("contract_unhealthy", dsl.StatusServiceUnavailable, func() {
+			dsl.Description("サーバは生きているが、ブロックチェーン上のスマートコントラクトと接続できない場合")
+		})
+	})
+
+	dsl.Method("Get health status.", func() {
+		dsl.Description("Check server health.")
+
+		dsl.HTTP(func() {
+			dsl.GET("/")
+
+			dsl.Response(dsl.StatusOK, func() {
+				dsl.Description("サービスが正常に機能している場合")
+			})
+		})
+	})
+})

--- a/server/gateways/api/gen/http/openapi3.yaml
+++ b/server/gateways/api/gen/http/openapi3.yaml
@@ -199,6 +199,28 @@ paths:
                         application/vnd.goa.error+json:
                             schema:
                                 $ref: '#/components/schemas/Error'
+    /api/health:
+        get:
+            tags:
+                - healthcheck
+            summary: Get health status. healthcheck
+            description: Check server health.
+            operationId: healthcheck#Get health status.
+            responses:
+                "200":
+                    description: サービスが正常に機能している場合
+                "500":
+                    description: 'database_unhealthy: サーバは生きているが、DBと接続できない場合'
+                    content:
+                        application/vnd.goa.error+json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                "503":
+                    description: 'contract_unhealthy: サーバは生きているが、ブロックチェーン上のスマートコントラクトと接続できない場合'
+                    content:
+                        application/vnd.goa.error+json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
     /api/nfts/{article_id}:
         post:
             tags:
@@ -295,7 +317,7 @@ paths:
                     enum:
                         - created_at
                         - updated_at
-                  example: created_at
+                  example: updated_at
                 - name: page_num
                   in: query
                   description: 取得したい位置のページ番号（1-indexed）
@@ -304,9 +326,9 @@ paths:
                     type: integer
                     description: 取得したい位置のページ番号（1-indexed）
                     default: 1
-                    example: 11672134284603955137
+                    example: 16801712174973070191
                     minimum: 1
-                  example: 13903759627942341001
+                  example: 12291431329987957870
                 - name: page_size
                   in: query
                   description: 1ページあたりのコンテンツ数
@@ -315,10 +337,10 @@ paths:
                     type: integer
                     description: 1ページあたりのコンテンツ数
                     default: 10
-                    example: 76
+                    example: 48
                     minimum: 1
                     maximum: 100
-                  example: 53
+                  example: 83
             responses:
                 "200":
                     description: OK response.
@@ -379,15 +401,15 @@ components:
                 cost:
                     type: integer
                     description: トークン発行にかかったコスト
-                    example: 5250902387539283934
+                    example: 2855234197662528398
                     format: int64
                 hash:
                     type: string
                     description: トランザクションのハッシュ
-                    example: Voluptatem debitis nesciunt nesciunt alias nulla.
+                    example: Esse excepturi rerum et odit qui.
             example:
-                cost: 3983753186087891933
-                hash: Odio voluptas voluptatibus sunt esse.
+                cost: 3391698048732303322
+                hash: Unde ducimus.
             required:
                 - hash
                 - cost
@@ -406,7 +428,7 @@ components:
                 signature:
                     type: string
                     description: '`address`のアカウントが行った署名'
-                    example: Magni maxime voluptates.
+                    example: Ipsa quis incidunt alias libero saepe.
                 title:
                     type: string
                     example: My Awesome Article
@@ -414,7 +436,7 @@ components:
             example:
                 address: '''0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'''
                 content: <h1> Hello World! </h1>
-                signature: Odit dolorem eius.
+                signature: Provident nobis qui itaque ipsum vel.
                 title: My Awesome Article
             required:
                 - title
@@ -458,10 +480,10 @@ components:
                 signature:
                     type: string
                     description: '`address`のアカウントが行った署名'
-                    example: Nisi dolor sapiente laboriosam veniam eos.
+                    example: Voluptatem debitis nesciunt nesciunt alias nulla.
             example:
                 address: '''0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'''
-                signature: Itaque et esse molestiae illum temporibus.
+                signature: Nihil odio voluptas voluptatibus.
             required:
                 - address
                 - signature
@@ -486,7 +508,7 @@ components:
                 fault:
                     type: boolean
                     description: Is the error a server-side fault?
-                    example: false
+                    example: true
                 id:
                     type: string
                     description: ID is a unique identifier for this particular occurrence of the problem.
@@ -506,7 +528,7 @@ components:
                 timeout:
                     type: boolean
                     description: Is the error a timeout?
-                    example: true
+                    example: false
             example:
                 id: 3F1FKVRR
                 message: Value of ID must be an integer
@@ -595,10 +617,13 @@ components:
                         - id: exampleId01
                           owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
                           title: My Awesome Article
+                        - id: exampleId01
+                          owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                          title: My Awesome Article
                 total_count:
                     type: integer
                     description: 指定したページを含めたすべての検索結果の件数
-                    example: 5023432583872562116
+                    example: 9646357824349231531
             example:
                 results:
                     - id: exampleId01
@@ -607,7 +632,7 @@ components:
                     - id: exampleId01
                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
                       title: My Awesome Article
-                total_count: 18413131499743742823
+                total_count: 11352710926538620347
             required:
                 - results
                 - total_count
@@ -626,7 +651,7 @@ components:
                 signature:
                     type: string
                     description: '`address`のアカウントが行った署名'
-                    example: Alias libero saepe officiis provident.
+                    example: Nisi dolor sapiente laboriosam veniam eos.
                 title:
                     type: string
                     example: My Awesome Article
@@ -636,7 +661,7 @@ components:
             example:
                 address: '''0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'''
                 content: <h1> Hello World! </h1>
-                signature: Qui itaque ipsum vel eligendi distinctio consectetur.
+                signature: Itaque et esse molestiae illum temporibus.
                 title: My Awesome Article
             required:
                 - address
@@ -646,6 +671,8 @@ tags:
       description: 記事サービス
     - name: articles-html
       description: SEO対策で、記事の表示だけ直接HTMLで返すためのサービス
+    - name: healthcheck
+      description: 疎通確認サービス
     - name: nfts
       description: NFTを管理するサービス
     - name: search

--- a/server/main.go
+++ b/server/main.go
@@ -49,6 +49,7 @@ func main() {
 	handler.AddService(services.NewArticlesHtmlService(db, *handler), "articles-html")
 	handler.AddService(services.NewNftsService(db, contract, s3Client, *handler), "nfts")
 	handler.AddService(services.NewSearchService(db, contract, *handler), "search")
+	handler.AddService(services.NewHealthcheckService(db, contract, *handler), "healthcheck")
 
 	logger.Info().Msg("Starting backend server...")
 	err = http.ListenAndServe(":8080", handler)

--- a/server/services/healthcheck.go
+++ b/server/services/healthcheck.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/team-azb/knowtfolio/server/gateways/api/gen/healthcheck"
+	"github.com/team-azb/knowtfolio/server/gateways/api/gen/http/healthcheck/server"
+	"github.com/team-azb/knowtfolio/server/gateways/ethereum"
+	goahttp "goa.design/goa/v3/http"
+	"gorm.io/gorm"
+)
+
+type healthcheckService struct {
+	DB       *gorm.DB
+	Contract *ethereum.ContractClient
+}
+
+func NewHealthcheckService(db *gorm.DB, contract *ethereum.ContractClient, handler HttpHandler) *server.Server {
+	endpoints := healthcheck.NewEndpoints(healthcheckService{DB: db, Contract: contract})
+	return server.New(
+		endpoints,
+		handler,
+		goahttp.RequestDecoder,
+		goahttp.ResponseEncoder,
+		nil,
+		nil)
+}
+
+func (s healthcheckService) GetHealthStatus(_ context.Context) (err error) {
+	// Check DB
+	db, err := s.DB.DB()
+	if err != nil {
+		return healthcheck.MakeDatabaseUnhealthy(err)
+	}
+	err = db.Ping()
+	if err != nil {
+		return healthcheck.MakeDatabaseUnhealthy(err)
+	}
+
+	// Check Blockchain
+	_, err = s.Contract.Name(&bind.CallOpts{})
+	if err != nil {
+		return healthcheck.MakeContractUnhealthy(err)
+	}
+
+	return nil
+}

--- a/server/services/healthcheck_test.go
+++ b/server/services/healthcheck_test.go
@@ -1,0 +1,59 @@
+package services
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/team-azb/knowtfolio/server/gateways/api/gen/http/healthcheck/server"
+	"github.com/team-azb/knowtfolio/server/models"
+	"testing"
+)
+
+func prepareHealthcheckService(t *testing.T) healthcheckService {
+	t.Parallel()
+
+	service := healthcheckService{
+		DB:       initTestDB(t),
+		Contract: initTestContractClient(t),
+	}
+	err := service.DB.AutoMigrate(models.Article{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return service
+}
+
+func TestGetHealthStatus(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		service := prepareHealthcheckService(t)
+
+		err := service.GetHealthStatus(context.Background())
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("FailWithoutDB", func(t *testing.T) {
+		service := prepareHealthcheckService(t)
+
+		db, err := service.DB.DB()
+		err = db.Close()
+		assert.NoError(t, err)
+
+		err = service.GetHealthStatus(context.Background())
+
+		var namer server.ErrorNamer
+		assert.ErrorAs(t, err, &namer)
+		assert.Equal(t, "database_unhealthy", namer.ErrorName())
+	})
+
+	t.Run("FailWithoutContractClient", func(t *testing.T) {
+		service := prepareHealthcheckService(t)
+
+		service.Contract.Close()
+		err := service.GetHealthStatus(context.Background())
+
+		var namer server.ErrorNamer
+		assert.ErrorAs(t, err, &namer)
+		assert.Equal(t, "contract_unhealthy", namer.ErrorName())
+	})
+}

--- a/server/services/init_test.go
+++ b/server/services/init_test.go
@@ -25,19 +25,19 @@ func initTestDB(t *testing.T) (db *gorm.DB) {
 		t.Skip("Tests using DB are skipped.")
 	}
 	// Connect to DB.
-	db, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/?parseTime=true"))
+	setupDB, err := gorm.Open(mysql.Open("root:password@tcp(db:3306)/?parseTime=true"))
 	fatalfIfError(t, err, "DB Connection failed")
 
 	// Create temporary database dedicated to this test call.
 	dbName := fmt.Sprintf("knowtfolio-db-test-%v", strings.ReplaceAll(t.Name(), "/", "_"))
-	res := db.Exec(fmt.Sprintf("CREATE DATABASE `%v`", dbName))
+	res := setupDB.Exec(fmt.Sprintf("CREATE DATABASE `%v`", dbName))
 	if res.Error != nil {
 		t.Fatalf("DB Creation failed: %v", res.Error)
 	}
 
 	// Make sure to drop the temporary database after the test.
 	t.Cleanup(func() {
-		_ = db.Exec(fmt.Sprintf("DROP DATABASE `%v`", dbName))
+		_ = setupDB.Exec(fmt.Sprintf("DROP DATABASE `%v`", dbName))
 	})
 
 	t.Logf("[%v] Created temporary DB %v!", t.Name(), dbName)


### PR DESCRIPTION
Closes #80 

`GET /health`でサーバの状態を確認できるようにした。
DBやContractとの疎通の確認も行われる。

また、テストの実装時に、Contractとの疎通がないシナリオを再現するために、`docker-compose.yml`でテスト時のプロトコルを`ws`に変え、接続を切断できるようにした（`http`だと接続という概念がないので、`Contract.Close()`を呼んでも切断できない）