### PR TITLE
記事の追加・編集ページのフロントエンドでのパスの変更

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,10 +37,11 @@ const App = () => {
               </AuthProvider>
             }
           />
-          {/* TODO: chenage endipoint to /articles/new */}
-          <Route path="/new" element={<NewArticlePage />} />
-          {/* TODO: chenage endipoint to /articles/:articleId/edit */}
-          <Route path="/edit/:articleId" element={<EditArticlePage />} />
+          <Route path="/articles/new" element={<NewArticlePage />} />
+          <Route
+            path="/articles/:articleId/edit"
+            element={<EditArticlePage />}
+          />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Web3Provider>

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -46,7 +46,7 @@ const NewArticlePage = () => {
         address: account,
         signature: signatureForMint,
       });
-      navigate(`/artcles/${id}`);
+      navigate(`/articles/${id}/edit`);
     } catch (error) {
       console.error(error);
       alert("記事の作成に失敗しました。");

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -98,5 +98,8 @@ module.exports = {
       rewrites: [{ from: /^\/*/, to: "/index.html" }],
     },
     port: 3000,
+    proxy: {
+      "/api": "http://localhost:8080",
+    },
   },
 };

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -89,6 +89,39 @@ resource "aws_cloudfront_distribution" "knowtfolio" {
     compress                 = true
   }
 
+  ordered_cache_behavior {
+    path_pattern             = "/articles/new"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    viewer_protocol_policy   = "allow-all"
+    target_origin_id         = aws_s3_bucket.knowtfolio_client.id
+    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
+    compress                 = true
+  }
+
+  ordered_cache_behavior {
+    path_pattern             = "/articles/*/edit"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    viewer_protocol_policy   = "allow-all"
+    target_origin_id         = aws_s3_bucket.knowtfolio_client.id
+    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
+    compress                 = true
+  }
+
+  ordered_cache_behavior {
+    path_pattern             = "/articles/*"
+    allowed_methods          = ["GET", "HEAD"]
+    cached_methods           = ["GET", "HEAD"]
+    viewer_protocol_policy   = "allow-all"
+    target_origin_id         = aws_lb.knowtfolio_backend.id
+    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
+    compress                 = true
+  }
+
   # TODO: SPAのルーティングの方法について考え直す
   custom_error_response {
     error_code         = 403

--- a/infrastructure/cloudfront.tf
+++ b/infrastructure/cloudfront.tf
@@ -95,7 +95,7 @@ resource "aws_cloudfront_distribution" "knowtfolio" {
     cached_methods           = ["GET", "HEAD"]
     viewer_protocol_policy   = "allow-all"
     target_origin_id         = aws_s3_bucket.knowtfolio_client.id
-    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" // CachingDisabled
     origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
     compress                 = true
   }
@@ -106,7 +106,7 @@ resource "aws_cloudfront_distribution" "knowtfolio" {
     cached_methods           = ["GET", "HEAD"]
     viewer_protocol_policy   = "allow-all"
     target_origin_id         = aws_s3_bucket.knowtfolio_client.id
-    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" // CachingDisabled
     origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
     compress                 = true
   }
@@ -117,7 +117,7 @@ resource "aws_cloudfront_distribution" "knowtfolio" {
     cached_methods           = ["GET", "HEAD"]
     viewer_protocol_policy   = "allow-all"
     target_origin_id         = aws_lb.knowtfolio_backend.id
-    cache_policy_id          = "658327ea-f89d-4fab-a63d-7e88639e58f6" // CachingOptimized
+    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad" // CachingDisabled
     origin_request_policy_id = "216adef6-5c7f-47e4-b989-5492eafa07d3" // AllViewer
     compress                 = true
   }


### PR DESCRIPTION
close #37 
- 記事の追加・編集ページのフロントエンドでのパスを変更した
  - `/new` -> `/articles/new`
  - `/:articleId` -> `/articles/:articleId/edit`
- `cloudfront`でも↑似合わせてパスのマッチングパターンを追加した
  - `/articles/new`と`/articles/:articleId/edit`の場合はフロントエンドのファイルへ、`/articles/:articleId`の場合はバックエンドのサーバーへ振り分ける設定を追加した。
- 開発者向けに、ローカル環境でフロントとバックエンドの疎通を行うためのproxy設定を追加した。 44a4f67 