### PR TITLE
NFTの有無をDBでも管理

### DIFF
--- a/server/models/article.go
+++ b/server/models/article.go
@@ -15,6 +15,7 @@ type Article struct {
 	Content               []byte
 	RawText               string `gorm:"index:search_idx,class:FULLTEXT"`
 	OriginalAuthorAddress string
+	IsTokenized           bool
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
 }
@@ -25,7 +26,14 @@ var rawTextSanitizer = bluemonday.StripTagsPolicy()
 func NewArticle(title string, content []byte, authorAddress string) *Article {
 	id, _ := nanoid.GenerateString(nanoid.DefaultAlphabet, 11)
 	rawText := rawTextSanitizer.Sanitize(string(content))
-	return &Article{ID: id, Title: title, Content: content, RawText: rawText, OriginalAuthorAddress: authorAddress}
+	return &Article{
+		ID:                    id,
+		Title:                 title,
+		Content:               content,
+		RawText:               rawText,
+		OriginalAuthorAddress: authorAddress,
+		IsTokenized:           false,
+	}
 }
 
 func (a *Article) SetTitleIfPresent(title *string) {
@@ -39,6 +47,10 @@ func (a *Article) SetContentIfPresent(content *string) {
 		a.Content = []byte(*content)
 		a.RawText = rawTextSanitizer.Sanitize(*content)
 	}
+}
+
+func (a *Article) SetIsTokenized() {
+	a.IsTokenized = true
 }
 
 func (a *Article) ToHTML() ([]byte, error) {

--- a/server/services/nfts_test.go
+++ b/server/services/nfts_test.go
@@ -88,6 +88,12 @@ func TestCreateNFTForArticle(t *testing.T) {
 	expectedJSON, jsonErr := metadata.ToJSON()
 	assert.NoError(t, reqErr, copyErr, jsonErr)
 	assert.JSONEq(t, string(expectedJSON), actualJSONBuf.String())
+
+	// Assert DB change.
+	target := models.Article{ID: article0.ID}
+	res := service.DB.First(&target)
+	assert.NoError(t, res.Error)
+	assert.True(t, target.IsTokenized)
 }
 
 func waitForNFTByHash(cli *ethereum.ContractClient, txHash string) bool {

--- a/server/services/search.go
+++ b/server/services/search.go
@@ -45,9 +45,10 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 			return nil, err
 		}
 		ownedByCond := s.DB.
+			// Articles that has been tokenized and whose token is owned by the user.
 			Where(`id IN ?`, ownedArticleIds).
-			// TODO: Add is_tokenized to avoid articles that has created by but not currently owned by `OwnedBy`.
-			Or(`original_author_address = ?`, *request.OwnedBy)
+			// Articles that hasn't been tokenized and is originally created by the user.
+			Or(s.DB.Where(`is_tokenized = 0`).Where(`original_author_address = ?`, *request.OwnedBy))
 		baseQuery = baseQuery.Where(ownedByCond)
 	}
 	if request.Keywords != nil {


### PR DESCRIPTION
Closes #76 

articleについて、NFTを発行済みかどうかのフラグ`IsTokenized`をDBで管理するようにした。
これにより以下の変更をおこなった。
* `POST /api/nfts/:id`で`IsTokenized`フィールドを更新
* `GET /api/search`で`IsTokenized`を用いた検索
* articlesサービスで`IsTokenized`を用いて認可ロジックを単純化