### PR TITLE
clientとinfraの修正

### DIFF
--- a/client/src/apis/cognito.ts
+++ b/client/src/apis/cognito.ts
@@ -5,6 +5,7 @@ import {
 } from "amazon-cognito-identity-js";
 import * as AmazonCognitoIdentity from "amazon-cognito-identity-js";
 import { userPool } from "~/configs/cognito";
+import Web3 from "web3";
 
 export const signOutFromCognito = (cognitoUser: CognitoUser) => {
   return new Promise<void>((resolve) => {
@@ -14,13 +15,13 @@ export const signOutFromCognito = (cognitoUser: CognitoUser) => {
   });
 };
 
-export const signInToCognitoWithPassword = async (
+export const signInToCognitoWithWallet = async (
   username: string,
-  password: string
+  web3: Web3,
+  account: string
 ) => {
   const authenticationData = {
     Username: username,
-    Password: password,
   };
   const authenticationDetails = new AmazonCognitoIdentity.AuthenticationDetails(
     authenticationData
@@ -44,8 +45,12 @@ export const signInToCognitoWithPassword = async (
       customChallenge: function (challengeParameters) {
         // User authentication depends on challenge response
         console.log(challengeParameters);
-        const challengeResponses = "challenge-answer";
-        cognitoUser.sendCustomChallengeAnswer(challengeResponses, this);
+        const signedMessage = web3.eth.personal.sign(
+          challengeParameters["sign_message"],
+          account,
+          ""
+        );
+        cognitoUser.sendCustomChallengeAnswer(signedMessage, this);
       },
     });
   });

--- a/client/src/components/pages/SignInPage/index.tsx
+++ b/client/src/components/pages/SignInPage/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
-import { signInToCognitoWithPassword } from "~/apis/cognito";
+import { signInToCognitoWithWallet } from "~/apis/cognito";
+import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 
 type signInWithPasswordForm = {
   username: string;
@@ -7,6 +8,7 @@ type signInWithPasswordForm = {
 };
 
 const SignInPage = () => {
+  const { web3, account } = useWeb3Context();
   const [form, setForm] = useState<signInWithPasswordForm>({
     username: "",
     password: "",
@@ -30,7 +32,7 @@ const SignInPage = () => {
 
   const signIn = useCallback(async () => {
     try {
-      await signInToCognitoWithPassword(form.username, form.password);
+      await signInToCognitoWithWallet(form.username, web3, account);
       alert("サインイン成功");
       window.location.reload();
     } catch (error) {

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -40,3 +40,9 @@ resource "aws_iam_role" "knowtfolio_auth_challenge_lambda" {
   name               = "knowtfolio-lambda-auth-challenge"
   assume_role_policy = file("${path.module}/templates/iam/knowtfolio_auth_challenge_lambda_assume_policy.json")
 }
+
+resource "aws_iam_role_policy" "basic_lambda_policy" {
+  name   = "basic-lambda-policy"
+  role   = aws_iam_role.knowtfolio_auth_challenge_lambda.name
+  policy = file("${path.module}/templates/iam/basic_lambda_policy.json")
+}

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -83,7 +83,7 @@ resource "null_resource" "build_go_functions" {
     working_dir = local.auth_challenge_func_dir
     environment = {
       GOARCH = "amd64"
-      GOOS = "linux"
+      GOOS   = "linux"
     }
   }
 
@@ -92,7 +92,7 @@ resource "null_resource" "build_go_functions" {
     working_dir = local.auth_challenge_func_dir
     environment = {
       GOARCH = "amd64"
-      GOOS = "linux"
+      GOOS   = "linux"
     }
   }
 
@@ -101,7 +101,7 @@ resource "null_resource" "build_go_functions" {
     working_dir = local.auth_challenge_func_dir
     environment = {
       GOARCH = "amd64"
-      GOOS = "linux"
+      GOOS   = "linux"
     }
   }
 }

--- a/infrastructure/templates/iam/basic_lambda_policy.json
+++ b/infrastructure/templates/iam/basic_lambda_policy.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ],
+        "Resource": [
+          "arn:aws:logs:*:*:*"
+        ]
+      },
+      {
+        "Action": [
+          "cloudwatch:Describe*",
+          "cloudwatch:Get*",
+          "cloudwatch:List*"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      }
+    ]
+  }


### PR DESCRIPTION
- clientで署名によるチャレンジを実装した。
- infrastructureでlambdaに対してcloudwatchのアクセス権限を付与した。

@shugo256  
現時点ではcognitoのcustom challengeが依然として、無条件に成功してしまう状態にある可能性が高い。
- clientで署名をするフローにそもそも行かない
- ↑でもサインインができてしまう

という状況

lambdaでlogは見れるようになったので、少しはデバッグしやすくなったはず