### PR TITLE
署名による認証がうまくいった

### DIFF
--- a/client/src/apis/cognito.ts
+++ b/client/src/apis/cognito.ts
@@ -42,10 +42,10 @@ export const signInToCognitoWithWallet = async (
       onFailure(err) {
         reject(err.message || JSON.stringify(err));
       },
-      customChallenge: function (challengeParameters) {
+      customChallenge: async function (challengeParameters) {
         // User authentication depends on challenge response
         console.log(challengeParameters);
-        const signedMessage = web3.eth.personal.sign(
+        const signedMessage = await web3.eth.personal.sign(
           challengeParameters["sign_message"],
           account,
           ""

--- a/infrastructure/function_scripts/auth_challenge/cmd/create/main.go
+++ b/infrastructure/function_scripts/auth_challenge/cmd/create/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func handler(event *events.CognitoEventUserPoolsCreateAuthChallenge) (*events.CognitoEventUserPoolsCreateAuthChallenge, error) {
-	fmt.Printf("Create Auth Challenge: %+v\n", event)
+	defer fmt.Printf("Create Auth Challenge: %+v\n", event)
 
 	nonceBytes := make([]byte, 32)
 	_, err := rand.Read(nonceBytes)
@@ -17,7 +17,7 @@ func handler(event *events.CognitoEventUserPoolsCreateAuthChallenge) (*events.Co
 		return nil, fmt.Errorf("could not generate nonce")
 	}
 
-	signMessage := fmt.Sprintf("Sign in to Knowtfolio. (nonce: %x)", nonceBytes)
+	signMessage := fmt.Sprintf("Sign in to Knowtfolio.\n(nonce: %x)", nonceBytes)
 	event.Response.PublicChallengeParameters = map[string]string{"sign_message": signMessage}
 	event.Response.PrivateChallengeParameters = map[string]string{"sign_message": signMessage}
 

--- a/infrastructure/function_scripts/auth_challenge/cmd/define/main.go
+++ b/infrastructure/function_scripts/auth_challenge/cmd/define/main.go
@@ -2,19 +2,28 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
 func handler(event *events.CognitoEventUserPoolsDefineAuthChallenge) (*events.CognitoEventUserPoolsDefineAuthChallenge, error) {
-	fmt.Printf("Define Auth Challenge: %+v\n", event)
+	defer fmt.Printf("Define Auth Challenge: %+v\n", event)
 
 	sessionLen := len(event.Request.Session)
-	if sessionLen > 0 && event.Request.Session[sessionLen-1].ChallengeResult {
-		event.Response.IssueTokens = true
+	if sessionLen > 0 && event.Request.Session[sessionLen-1].ChallengeName == "CUSTOM_CHALLENGE" {
+		if event.Request.Session[sessionLen-1].ChallengeResult {
+			event.Response.IssueTokens = true
+		} else {
+			event.Response.FailAuthentication = true
+		}
 	} else {
-		event.Response.ChallengeName = "SIGNATURE_CHALLENGE"
+		_, hasWallet := event.Request.UserAttributes["custom:wallet_address"]
+		if hasWallet {
+			event.Response.ChallengeName = "CUSTOM_CHALLENGE"
+		} else {
+			// Fail if the cognito user is not tied to a wallet.
+			event.Response.FailAuthentication = true
+		}
 	}
 
 	return event, nil

--- a/infrastructure/function_scripts/auth_challenge/cmd/verify/main.go
+++ b/infrastructure/function_scripts/auth_challenge/cmd/verify/main.go
@@ -12,9 +12,10 @@ import (
 )
 
 func handler(event *events.CognitoEventUserPoolsVerifyAuthChallenge) (*events.CognitoEventUserPoolsVerifyAuthChallenge, error) {
-	fmt.Printf("Verify Auth Challenge: %+v\n", event)
+	defer fmt.Printf("Verify Auth Challenge: %+v\n", event)
 
-	address := event.Request.UserAttributes["wallet_address"]
+	// `custom:wallet_address` should exist after passing the `define` phase.
+	address := event.Request.UserAttributes["custom:wallet_address"]
 	sign := event.Request.ChallengeAnswer.(string)
 	signedData := event.Request.PrivateChallengeParameters["sign_message"]
 

--- a/infrastructure/lambda.tf
+++ b/infrastructure/lambda.tf
@@ -51,6 +51,13 @@ resource "aws_lambda_function" "create_auth_challenge" {
   runtime          = "go1.x"
 }
 
+resource "aws_lambda_permission" "create_auth_challenge" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.create_auth_challenge.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.knowtfolio.arn
+}
+
 
 data "archive_file" "verify_auth_challenge_response" {
   type        = "zip"
@@ -68,6 +75,13 @@ resource "aws_lambda_function" "verify_auth_challenge_response" {
   source_code_hash = data.archive_file.verify_auth_challenge_response.output_base64sha256
   handler          = "verify"
   runtime          = "go1.x"
+}
+
+resource "aws_lambda_permission" "verify_auth_challenge_response" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.verify_auth_challenge_response.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.knowtfolio.arn
 }
 
 resource "null_resource" "build_go_functions" {


### PR DESCRIPTION
AWSのコンソールで`custom:wallet_address`をセットした上で、そのアドレスをwalletにセットしてログインページでユーザ名を入力すると、署名を求められて、ログインが成功する。
一方で、`custom:wallet_address`にセットしたものとは別のアドレスで署名すると、ちゃんと失敗する。
また、`custom:wallet_address`をセットしない場合も失敗する

変更点：
* defineと同様にcreateとverifyも実行できるように権限を付与した（コピペ）
* defineで設定していたchallengeNameを`CUSTOM_AUTH`に戻した（こうしないとcreateに進めない（だったらstringではなくenumにしてくれ））
* 認証失敗時にdefineで`FailAuthentication`をtrueにするようにした（こうしないと失敗パターンでは無限ループする）
  * ここで、`wallet_address`のフィールドのないユーザに関しては初手で失敗するようにした
* cognito.tsの`signedMessage`が`Promise`になっていて、送信に失敗していたので、`await`をつけた