### PR TITLE
サイト内の遷移リンクの実装+α

### DIFF
--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -76,7 +76,7 @@ type searchQuery = {
   page_size?: number;
 };
 export const searchArticles = async (queryParams: searchQuery = {}) => {
-  const { data } = await axios.get<searchArticlesResponse>("api/search", {
+  const { data } = await axios.get<searchArticlesResponse>("/api/search", {
     params: queryParams,
   });
   return data;

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import AuthProvider, {
   useAuthContext,
 } from "~/components/organisms/providers/AuthProvider";
@@ -8,9 +9,17 @@ const AcountInfo = () => {
 };
 
 const Header = () => {
+  const navigate = useNavigate();
   return (
     <div>
-      <h1>knowtfolio</h1>
+      <h1
+        style={{ cursor: "pointer" }}
+        onClick={() => {
+          navigate("/");
+        }}
+      >
+        knowtfolio
+      </h1>
       <AuthProvider contentOnUnauthenticated={<p>未認証ユーザー</p>}>
         <AcountInfo />
       </AuthProvider>

--- a/client/src/components/pages/TopPage/index.tsx
+++ b/client/src/components/pages/TopPage/index.tsx
@@ -1,67 +1,25 @@
-import styles from "./style.module.css";
-import { greeting } from "./helper";
-import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import detectEthereumProvider from "@metamask/detect-provider";
-import Web3 from "web3";
 
 const TopPage = () => {
-  const [account, setAccount] = useState("");
-  const [balance, setBalance] = useState("");
-  const [isConnected, setIsConnected] = useState(false);
-
-  useEffect(() => {
-    // Reload when account is changed
-    window.ethereum.on("accountsChanged", () => {
-      // Handle the new accounts, or lack thereof.
-      window.location.reload();
-    });
-    // Reload when chain is changed
-    window.ethereum.on("chainChanged", () => {
-      // Handle the new chain.
-      window.location.reload();
-    });
-  }, []);
-
-  const connectMetamask = useCallback(async () => {
-    const provider = await detectEthereumProvider({ mustBeMetaMask: true });
-    if (provider && window.ethereum?.isMetaMask) {
-      console.log("Welcome to MetaMask User🎉");
-      const web3 = new Web3(Web3.givenProvider);
-      // connect with metamask wallet
-      const accounts = await web3.eth.requestAccounts();
-      const account = accounts[0];
-
-      const balance = await web3.eth.getBalance(accounts[0]);
-
-      setAccount(account);
-      setBalance(web3.utils.fromWei(balance));
-      setIsConnected(true);
-      greeting();
-    } else {
-      console.log("Please Install MetaMask🙇‍♂️");
-    }
-  }, []);
-
-  // Initialize connection with contract and wallet
-  useEffect(() => {
-    connectMetamask();
-  }, [connectMetamask]);
-
   return (
     <div>
-      <h1 className={styles.title}>hello web3!!</h1>
-      {isConnected ? (
-        <>
-          <p>your account: {account}</p>
-          <p>your balance: {balance}</p>
-        </>
-      ) : (
-        "未接続"
-      )}
-      <div>
-        <Link to="/signup">signup</Link>
-      </div>
+      <ul>
+        <li>
+          <Link to={"/signin"}>サインイン</Link>
+        </li>
+        <li>
+          <Link to={"/signup"}>サインアップ</Link>
+        </li>
+        <li>
+          <Link to={"/mypage"}>マイページ</Link>
+        </li>
+        <li>
+          <Link to={"/articles/new"}>記事作成</Link>
+        </li>
+        <li>
+          <Link to={"/articles"}>記事一覧</Link>
+        </li>
+      </ul>
     </div>
   );
 };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -100,12 +100,16 @@ module.exports = {
     port: 3000,
     proxy: [
       {
-        context: [
-          "/api/**",
-          "/articles/**",
-          "!/articles/new",
-          "!/articles/**/edit",
-        ],
+        context: (path) => {
+          if (path.includes("/api")) {
+            return true;
+          } else if (/\/articles\/.+/.test(path)) {
+            const editMatcher = /articles\/\w+\/edit/g;
+            return !path.includes("/articles/new") && !path.match(editMatcher);
+          } else {
+            return false;
+          }
+        },
         target: "http://server:8080",
       },
     ],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = {
           if (path.includes("/api")) {
             return true;
           } else if (/\/articles\/.+/.test(path)) {
-            const editMatcher = /articles\/\w+\/edit/g;
+            const editMatcher = /\/articles\/.+\/edit/g;
             return !path.includes("/articles/new") && !path.match(editMatcher);
           } else {
             return false;

--- a/server/models/article.go
+++ b/server/models/article.go
@@ -62,6 +62,8 @@ func (a *Article) ToHTML() ([]byte, error) {
 				<title> {{ .title }} </title>
 			</head>
 			<body>
+				<a href="/articles">記事一覧</a>
+				<a href="/articles/{{ .id }}/edit">記事を編集</a>
 				<h1> {{ .title }} </h1>
 				{{ .content }}
 			</body>
@@ -73,6 +75,7 @@ func (a *Article) ToHTML() ([]byte, error) {
 	var buf bytes.Buffer
 	err = htmlTemplate.Execute(&buf, map[string]interface{}{
 		"title":   a.Title,
+		"id":      a.ID,
 		"content": template.HTML(htmlSanitizer.SanitizeBytes(a.Content)),
 	})
 	if err != nil {

--- a/server/models/article_test.go
+++ b/server/models/article_test.go
@@ -1,12 +1,13 @@
 package models
 
 import (
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSetTitleIfPresent(t *testing.T) {
@@ -52,6 +53,8 @@ func TestToHtml(t *testing.T) {
 				<title> Hello Knowtfolio! </title>
 			</head>
 			<body>
+				<a href="/articles">記事一覧</a>
+				<a href="/articles/abcdefghijk/edit">記事を編集</a>
 				<h1> Hello Knowtfolio! </h1>
 				<div> Hello HTML! </div>
 			</body>`


### PR DESCRIPTION
close #99 
- サイト内を遷移しやすくするリンクを作成した
  - ヘッダーの`Knowtfolio`のロゴからトップページに遷移できるようにした
  - トップページにあった、遺産とも言える無意味コンテンツを削除し、主要なページへの遷移リンクのリストを表示した
  - 記事ページに、記事一覧画面と、記事編集画面への遷移リンクを実装した
-  webpackのproxyの設定を修正した
  `/articles`はフロントに飛ばさないといけないが、既存の設定だとバックエンドに飛んで行ってしまう。ワイルドカードを使った設定に追加して乗り越えたかったが、難しそうだったので、少し可読性が落ちるが、関数を使ったカスタムでの実装で修正した。
- バックエンドのエンドポイントの呼び出しのパス指定の微修正
  `client/src/apis/knowtfolio.ts`にて、パスの指定を相対パスで行っていたため、絶対パスのような書き方に修正した。（相対パスで指定していると、現在のページのパスからの相対パスで指定することになる）
