### PR TITLE
tinymceのeditorをリッチにした

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,6 +15,7 @@
         "@tinymce/tinymce-react": "^4.1.0",
         "amazon-cognito-identity-js": "^5.2.9",
         "axios": "^0.27.2",
+        "nanoid": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
@@ -7380,15 +7381,14 @@
       "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^14 || ^16 || >=18"
       }
     },
     "node_modules/natural-compare": {
@@ -8497,6 +8497,18 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -17011,10 +17023,9 @@
       "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew=="
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+      "integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -17469,6 +17480,14 @@
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
+      },
+      "dependencies": {
+        "nanoid": {
+          "version": "3.3.4",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+          "dev": true
+        }
       }
     },
     "postcss-calc": {

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@tinymce/tinymce-react": "^4.1.0",
     "amazon-cognito-identity-js": "^5.2.9",
     "axios": "^0.27.2",
+    "nanoid": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/client/src/apis/s3.ts
+++ b/client/src/apis/s3.ts
@@ -1,5 +1,7 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { fromCognitoIdentityPool } from "@aws-sdk/credential-providers";
+import { useMemo } from "react";
+import { useAuthContext } from "~/components/organisms/providers/AuthProvider";
 import { COGNITO_USER_POOL_ID } from "~/configs/cognito";
 import {
   COGNITO_IDENTITY_POOL_ID,
@@ -28,4 +30,23 @@ export const createPutImageObjectCommand = (key: string, blob: Blob) => {
     Key: key,
     Body: blob,
   });
+};
+
+export const useS3Client = () => {
+  const { session } = useAuthContext();
+  const s3Client = useMemo(() => {
+    return getS3Client(
+      fromCognitoIdentityPool({
+        identityPoolId: COGNITO_IDENTITY_POOL_ID,
+        logins: {
+          [`cognito-idp.ap-northeast-1.amazonaws.com/${COGNITO_USER_POOL_ID}`]:
+            session.getIdToken().getJwtToken(),
+        },
+        clientConfig: {
+          region: "ap-northeast-1",
+        },
+      })
+    );
+  }, [session]);
+  return s3Client;
 };

--- a/client/src/components/organisms/ArticleEditForm/index.tsx
+++ b/client/src/components/organisms/ArticleEditForm/index.tsx
@@ -1,13 +1,9 @@
 import { useParams } from "react-router-dom";
-import { Editor } from "@tinymce/tinymce-react";
 import { Editor as TinyMCEEditor } from "tinymce";
-import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useEffect, useState } from "react";
 import { getArticle, putArticle } from "~/apis/knowtfolio";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
-import { ARTICLE_RESOURCES_S3_BUCKET } from "~/configs/s3";
-import { PutObjectCommand } from "@aws-sdk/client-s3";
-import { useS3Client } from "~/apis/s3";
+import ArticleEditor from "~/components/organisms/ArticleEditor";
 
 const ArticleEditForm = () => {
   const { articleId } = useParams();
@@ -19,7 +15,6 @@ const ArticleEditForm = () => {
     setContent(value);
   }, []);
   const { web3, account } = useWeb3Context();
-  const s3Client = useS3Client();
 
   useEffect(() => {
     (async () => {
@@ -59,30 +54,7 @@ const ArticleEditForm = () => {
   return (
     <>
       <h1>Edit Article: {articleId}</h1>
-      <Editor
-        onEditorChange={handleEditorChange}
-        value={content}
-        apiKey={TINY_MCE_API_KEY}
-        init={{
-          height: 500,
-          menubar: true,
-          content_style:
-            "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
-          images_upload_handler: async (blobInfo) => {
-            const timestamp = new Date().getTime();
-            const filename = `${timestamp}_${blobInfo.filename()}`;
-            const command = new PutObjectCommand({
-              Bucket: ARTICLE_RESOURCES_S3_BUCKET,
-              Key: `images/${filename}`,
-              Body: blobInfo.blob(),
-              ContentType: blobInfo.blob().type,
-            });
-            await s3Client.send(command);
-            return `https://knowtfolio.com/images/${filename}`;
-          },
-        }}
-        plugins={["image"]}
-      />
+      <ArticleEditor onEditorChange={handleEditorChange} value={content} />
       <p>preview</p>
       <div>{content}</div>
       <button onClick={handleUpdate}>update article</button>

--- a/client/src/components/organisms/ArticleEditForm/index.tsx
+++ b/client/src/components/organisms/ArticleEditForm/index.tsx
@@ -5,6 +5,9 @@ import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useEffect, useState } from "react";
 import { getArticle, putArticle } from "~/apis/knowtfolio";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
+import { ARTICLE_RESOURCES_S3_BUCKET } from "~/configs/s3";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { useS3Client } from "~/apis/s3";
 
 const ArticleEditForm = () => {
   const { articleId } = useParams();
@@ -16,6 +19,7 @@ const ArticleEditForm = () => {
     setContent(value);
   }, []);
   const { web3, account } = useWeb3Context();
+  const s3Client = useS3Client();
 
   useEffect(() => {
     (async () => {
@@ -64,7 +68,20 @@ const ArticleEditForm = () => {
           menubar: true,
           content_style:
             "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
+          images_upload_handler: async (blobInfo) => {
+            const timestamp = new Date().getTime();
+            const filename = `${timestamp}_${blobInfo.filename()}`;
+            const command = new PutObjectCommand({
+              Bucket: ARTICLE_RESOURCES_S3_BUCKET,
+              Key: `images/${filename}`,
+              Body: blobInfo.blob(),
+              ContentType: blobInfo.blob().type,
+            });
+            await s3Client.send(command);
+            return `https://knowtfolio.com/images/${filename}`;
+          },
         }}
+        plugins={["image"]}
       />
       <p>preview</p>
       <div>{content}</div>

--- a/client/src/components/organisms/ArticleEditor/index.tsx
+++ b/client/src/components/organisms/ArticleEditor/index.tsx
@@ -1,17 +1,43 @@
 import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { Editor } from "@tinymce/tinymce-react";
 import { Editor as TinyMCEEditor } from "tinymce";
+import { nanoid } from "nanoid";
 import { useS3Client } from "~/apis/s3";
 import { ARTICLE_RESOURCES_S3_BUCKET } from "~/configs/s3";
 import { TINY_MCE_API_KEY } from "~/configs/tinymce";
+import { useCallback } from "react";
 
 type articleEditorProps = {
   onEditorChange?: (a: string, editor: TinyMCEEditor) => void;
   value?: string;
 };
 
+const extractExtension = (filename: string) => {
+  const arr = filename.split(".");
+  return arr.length > 0 ? `.${arr.pop()}` : "";
+};
+
 const ArticleEditor = ({ onEditorChange, value }: articleEditorProps) => {
   const s3Client = useS3Client();
+
+  const imageUploadHandler = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (blobInfo: any) => {
+      const timestamp = new Date().getTime();
+      const filename = `${timestamp}_${nanoid(6)}${extractExtension(
+        blobInfo.filename()
+      )}`;
+      const command = new PutObjectCommand({
+        Bucket: ARTICLE_RESOURCES_S3_BUCKET,
+        Key: `images/${filename}`,
+        Body: blobInfo.blob(),
+        ContentType: blobInfo.blob().type,
+      });
+      await s3Client.send(command);
+      return encodeURI(`https://knowtfolio.com/images/${filename}`);
+    },
+    [s3Client]
+  );
 
   return (
     <Editor
@@ -23,18 +49,7 @@ const ArticleEditor = ({ onEditorChange, value }: articleEditorProps) => {
         menubar: true,
         content_style:
           "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
-        images_upload_handler: async (blobInfo) => {
-          const timestamp = new Date().getTime();
-          const filename = `${timestamp}_${blobInfo.filename()}`;
-          const command = new PutObjectCommand({
-            Bucket: ARTICLE_RESOURCES_S3_BUCKET,
-            Key: `images/${filename}`,
-            Body: blobInfo.blob(),
-            ContentType: blobInfo.blob().type,
-          });
-          await s3Client.send(command);
-          return encodeURI(`https://knowtfolio.com/images/${filename}`);
-        },
+        images_upload_handler: imageUploadHandler,
         text_patterns: [
           { start: "*", end: "*", format: "italic" },
           { start: "**", end: "**", format: "bold" },

--- a/client/src/components/organisms/ArticleEditor/index.tsx
+++ b/client/src/components/organisms/ArticleEditor/index.tsx
@@ -1,0 +1,91 @@
+import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { Editor } from "@tinymce/tinymce-react";
+import { Editor as TinyMCEEditor } from "tinymce";
+import { useS3Client } from "~/apis/s3";
+import { ARTICLE_RESOURCES_S3_BUCKET } from "~/configs/s3";
+import { TINY_MCE_API_KEY } from "~/configs/tinymce";
+
+type articleEditorProps = {
+  onEditorChange?: (a: string, editor: TinyMCEEditor) => void;
+  value?: string;
+};
+
+const ArticleEditor = ({ onEditorChange, value }: articleEditorProps) => {
+  const s3Client = useS3Client();
+
+  return (
+    <Editor
+      onEditorChange={onEditorChange}
+      value={value}
+      apiKey={TINY_MCE_API_KEY}
+      init={{
+        height: 500,
+        menubar: true,
+        content_style:
+          "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
+        images_upload_handler: async (blobInfo) => {
+          const timestamp = new Date().getTime();
+          const filename = `${timestamp}_${blobInfo.filename()}`;
+          const command = new PutObjectCommand({
+            Bucket: ARTICLE_RESOURCES_S3_BUCKET,
+            Key: `images/${filename}`,
+            Body: blobInfo.blob(),
+            ContentType: blobInfo.blob().type,
+          });
+          await s3Client.send(command);
+          return `https://knowtfolio.com/images/${filename}`;
+        },
+        text_patterns: [
+          { start: "*", end: "*", format: "italic" },
+          { start: "**", end: "**", format: "bold" },
+          { start: "#", format: "h1" },
+          { start: "##", format: "h2" },
+          { start: "###", format: "h3" },
+          { start: "####", format: "h4" },
+          { start: "#####", format: "h5" },
+          { start: "######", format: "h6" },
+          { start: "`", end: "`", format: "code" },
+          // The following text patterns require the `lists` plugin
+          { start: "1. ", cmd: "InsertOrderedList" },
+          {
+            start: "a. ",
+            cmd: "InsertOrderedList",
+            value: { "list-style-type": "lower-alpha" },
+          },
+          {
+            start: "i. ",
+            cmd: "InsertOrderedList",
+            value: { "list-style-type": "lower-roman" },
+          },
+          { start: "* ", cmd: "InsertUnorderedList" },
+          { start: "- ", cmd: "InsertUnorderedList" },
+        ],
+      }}
+      toolbar={[
+        "undo redo | styles | bold italic codeformat underline | fontfamily fontsize forecolor | alignleft aligncenter alignright",
+        "emoticons anchor link image media | numlist bullist table | codesample | wordcount searchreplace preview visualblocks help",
+      ]}
+      plugins={[
+        "image",
+        "textpattern",
+        "preview",
+        "lists",
+        "advlist",
+        "link",
+        "autolink",
+        "table",
+        "anchor",
+        "code",
+        "codesample",
+        "emoticons",
+        "searchreplace",
+        "visualblocks",
+        "media",
+        "wordcount",
+        "help",
+      ]}
+    />
+  );
+};
+
+export default ArticleEditor;

--- a/client/src/components/organisms/ArticleEditor/index.tsx
+++ b/client/src/components/organisms/ArticleEditor/index.tsx
@@ -33,7 +33,7 @@ const ArticleEditor = ({ onEditorChange, value }: articleEditorProps) => {
             ContentType: blobInfo.blob().type,
           });
           await s3Client.send(command);
-          return `https://knowtfolio.com/images/${filename}`;
+          return encodeURI(`https://knowtfolio.com/images/${filename}`);
         },
         text_patterns: [
           { start: "*", end: "*", format: "italic" },

--- a/client/src/components/pages/NewArticlePage/index.tsx
+++ b/client/src/components/pages/NewArticlePage/index.tsx
@@ -1,10 +1,9 @@
-import { Editor } from "@tinymce/tinymce-react";
 import { Editor as TinyMCEEditor } from "tinymce";
-import { TINY_MCE_API_KEY } from "~/configs/tinymce";
 import { useCallback, useState } from "react";
 import { mintArticleNft, postArticle } from "~/apis/knowtfolio";
 import { useNavigate } from "react-router-dom";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
+import ArticleEditor from "~/components/organisms/ArticleEditor";
 
 const NewArticlePage = () => {
   const [content, setContent] = useState("");
@@ -60,17 +59,7 @@ const NewArticlePage = () => {
         title:{" "}
         <input type="text" onChange={changeTitleInput} value={titleInput} />
       </p>
-      <Editor
-        onEditorChange={handleEditorChange}
-        value={content}
-        apiKey={TINY_MCE_API_KEY}
-        init={{
-          height: 500,
-          menubar: true,
-          content_style:
-            "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
-        }}
-      />
+      <ArticleEditor onEditorChange={handleEditorChange} value={content} />
       <p>preview</p>
       <div>{content}</div>
       <button onClick={handlePost}>create article</button>


### PR DESCRIPTION
close #103  #105
tinymceのプラグインを利用可能なもののうち、使えそうなものをアドオンした。
- 画像アップロード
- 動画の埋め込み
- リスト
- テーブル
- リンク
- コードブロック
- テキストパターン
などなど

ここで、画像のアップロードには`s3`のapiを用いる必要があるため、この設定をtinymce側でも行った。
テキストパターンはmarkdownチックにタグを生成したりできるが、限界があったので、別で`markdown2html`の機能を今後つける必要がある。#106 に追記しておいた。テキストパターンの限界の詳細は以下
- code block(```で囲むやつ)とリンク(`[]()`で作るやつ)が実装できなかった。
- githubのように、マークダウンで最後までコンテンツを書き上げることができない。(あくまでも、タグの生成を補助するツールとしてしか使えない)

tinymceのeditorのコンポーネントが、新規記事作成画面と記事編集画面で共通化されていなかったので、共通化した。