### PR TITLE
Document tableのRawTextのカラムのtypeを変更

### DIFF
--- a/server/models/document.go
+++ b/server/models/document.go
@@ -1,9 +1,9 @@
 package models
 
 import (
+	"time"
 	"github.com/aidarkhanov/nanoid/v2"
 	"github.com/microcosm-cc/bluemonday"
-	"time"
 )
 
 type DocumentType string
@@ -18,7 +18,7 @@ type Document struct {
 	OwnerType DocumentType `gorm:"not null; enum('ARTICLE')"`
 	Title     string       `gorm:"not null; index:search_idx,class:FULLTEXT"`
 	Content   []byte       `gorm:"not null"`
-	RawText   string       `gorm:"not null; index:search_idx,class:FULLTEXT"`
+	RawText   string       `gorm:"type:text not null; index:search_idx,class:FULLTEXT"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/server/models/document.go
+++ b/server/models/document.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"time"
+
 	"github.com/aidarkhanov/nanoid/v2"
 	"github.com/microcosm-cc/bluemonday"
 )
@@ -18,7 +19,7 @@ type Document struct {
 	OwnerType DocumentType `gorm:"not null; enum('ARTICLE')"`
 	Title     string       `gorm:"not null; index:search_idx,class:FULLTEXT"`
 	Content   []byte       `gorm:"not null"`
-	RawText   string       `gorm:"type:text not null; index:search_idx,class:FULLTEXT"`
+	RawText   string       `gorm:"not null; type:text; index:search_idx,class:FULLTEXT"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }


### PR DESCRIPTION
記事をアップロードする際に、DocumentテーブルのRawTextがサイズオーバーしてしまうとmysqlからエラーが出ていたので、対応した。`size`でサイズ(byte?)を直接指定できそうだが、文字数の上限がよくわからなかったので、`type:text`で指定することにした。  
参考：https://gorm.io/docs/data_types.html