### PR TITLE
`GET /search`で`owned_by`などの条件指定時に、`total_count`が正しく反映されないことがある問題を修正

### DIFF
--- a/server/services/search.go
+++ b/server/services/search.go
@@ -59,12 +59,15 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 		baseQuery = baseQuery.Where(`MATCH(title, raw_text) against(? IN BOOLEAN MODE)`, strings.Join(keywords, " "))
 	}
 
+	// NOTE: Need to call `Session` here to make baseQuery sharable.
+	// https://gorm.io/ja_JP/docs/method_chaining.html#New-Session-Method
+	baseQuery = baseQuery.Joins("Document").Session(&gorm.Session{})
+
 	// Branch loading query and counting query from baseQuery.
 	offset := int((request.PageNum - 1) * request.PageSize)
 	limit := int(request.PageSize)
 	loadQuery := baseQuery.
 		Select("articles.id", "original_author_address").
-		Joins("Document").
 		Offset(offset).Limit(limit).Order(request.SortBy)
 	countQuery := baseQuery.Model(&models.Article{})
 

--- a/server/services/search_test.go
+++ b/server/services/search_test.go
@@ -129,4 +129,30 @@ func TestSearchForArticles(t *testing.T) {
 		assert.EqualValues(t, len(expectedResults), result2.TotalCount)
 		assert.EqualValues(t, len(expectedResults), result3.TotalCount)
 	})
+
+	t.Run("PaginationWithConds", func(t *testing.T) {
+		service := prepareSearchService(t)
+
+		keywords := "language"
+		result1, err1 := service.SearchForArticles(context.Background(), &search.SearchRequest{
+			Keywords: &keywords,
+			OwnedBy:  &user0Addr,
+			PageSize: 1,
+			PageNum:  1,
+		})
+		result2, err2 := service.SearchForArticles(context.Background(), &search.SearchRequest{
+			Keywords: &keywords,
+			OwnedBy:  &user0Addr,
+			PageSize: 1,
+			PageNum:  2,
+		})
+		combinedResults := append(result1.Results, result2.Results...)
+
+		// Assert request body.
+		expectedResults := []*search.SearchResultEntry{&pyEntry, &jsEntry}
+		assert.NoError(t, multierr.Combine(err1, err2))
+		assert.ElementsMatch(t, expectedResults, combinedResults)
+		assert.EqualValues(t, len(expectedResults), result1.TotalCount)
+		assert.EqualValues(t, len(expectedResults), result2.TotalCount)
+	})
 }


### PR DESCRIPTION
Closes #176 

今回の症状に対応するテストを追加し、それが通るよう修正した

原因は`SearchForArticles`メソッドで、`baseQuery`をデータ取得用の`loadQuery`と、カウント用の`countQuery`に分岐させていたところで、`Session`メソッドなどの[New Session Method](https://gorm.io/ja_JP/docs/method_chaining.html#New-Session-Method)を呼んでいなかったこと。これを呼ばないと、この箇所のように複数の実行でクエリオブジェクトを共有できないっぽい。