### PR TITLE
マイページの`Article Collection`に表示されるカードのeditボタンを押すと、編集ページに飛ばないバグの修正

### DIFF
--- a/client/src/components/molecules/ArticleCardBase/index.tsx
+++ b/client/src/components/molecules/ArticleCardBase/index.tsx
@@ -14,7 +14,12 @@ type articleCardProps = GridProps & {
  * @lowerContent 記事カードの下部に表示する要素
  * @onClick 記事カードをクリックした場合のハンドラ
  */
-const ArticleCardBase = (props: articleCardProps) => {
+const ArticleCardBase = ({
+  onClick,
+  title,
+  lowerContent,
+  ...gridProps
+}: articleCardProps) => {
   return (
     <Grid
       container
@@ -24,18 +29,18 @@ const ArticleCardBase = (props: articleCardProps) => {
         borderRadius: 8,
         padding: "1rem",
       }}
-      {...props}
+      {...gridProps}
     >
       <Grid
         item
         style={{ height: "10rem", cursor: "pointer" }}
-        onClick={props.onClick}
+        onClick={onClick}
       >
         <h3 style={{ fontWeight: "normal" }}>
-          <TrancatedText text={props.title} m={25} n={5} />
+          <TrancatedText text={title} m={25} n={5} />
         </h3>
       </Grid>
-      <Grid item>{props.lowerContent}</Grid>
+      <Grid item>{lowerContent}</Grid>
     </Grid>
   );
 };

--- a/client/src/components/molecules/ArticleCardBase/index.tsx
+++ b/client/src/components/molecules/ArticleCardBase/index.tsx
@@ -18,7 +18,7 @@ const ArticleCardBase = ({
   onClick,
   title,
   lowerContent,
-  ...gridProps
+  ...outerGridProps
 }: articleCardProps) => {
   return (
     <Grid
@@ -29,7 +29,7 @@ const ArticleCardBase = ({
         borderRadius: 8,
         padding: "1rem",
       }}
-      {...gridProps}
+      {...outerGridProps}
     >
       <Grid
         item


### PR DESCRIPTION
### 原因
- `ArticleCardBase`コンポーネントでのpropsの使い方に問題があった
- onClickのpropsが、`ArticleCardBase`全体に適用されるようになってしまっていた。（本来は記事のタイトル表示の箇所だけに適用させる仕様）
- editボタンを押す → editボタンに指定されている編集ページへの遷移がトリガーされる → カード全体(ArticleCardBaseに対応)に指定されている記事ページへの遷移もトリガーされる → 編集ページ、記事ページと2段階で飛ばされる
### 対応
- `ArticleCardBase`でonClickのpropsを`ArticleCardBase`全体に適用しないように修正した。