### PR TITLE
アラート関連のUIをToastできれいに

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "react-dom": "^18.2.0",
         "react-phone-number-input": "^3.2.11",
         "react-router-dom": "^6.4.0",
+        "react-toastify": "^9.0.8",
         "web3": "^1.7.4"
       },
       "devDependencies": {
@@ -9835,6 +9836,18 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.8.tgz",
+      "integrity": "sha512-EwM+teWt49HSHx+67qI08yLAW1zAsBxCXLCsUfxHYv1W7/R3ZLhrqKalh7j+kjgPna1h5LQMSMwns4tB4ww2yQ==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-transition-group": {
@@ -19790,6 +19803,14 @@
       "integrity": "sha512-4Aw1xmXKeleYYQ3x0Lcl2undHR6yMjXZjd9DKZd53SGOYqirrUThyUb0wwAX5VZAyvSuzjNJmZlJ3rR9+/vzqg==",
       "requires": {
         "react-router": "6.4.0"
+      }
+    },
+    "react-toastify": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.0.8.tgz",
+      "integrity": "sha512-EwM+teWt49HSHx+67qI08yLAW1zAsBxCXLCsUfxHYv1W7/R3ZLhrqKalh7j+kjgPna1h5LQMSMwns4tB4ww2yQ==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^18.2.0",
     "react-phone-number-input": "^3.2.11",
     "react-router-dom": "^6.4.0",
+    "react-toastify": "^9.0.8",
     "web3": "^1.7.4"
   },
   "devDependencies": {

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,8 @@ import Web3Provider from "~/components/organisms/providers/Web3Provider";
 import ResetWalletPage from "./components/pages/ResetWalletPage";
 import { ThemeProvider } from "@mui/material";
 import { theme } from "~/configs/theme";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 import "~/global.css";
 
 const App = () => {
@@ -67,6 +69,7 @@ const App = () => {
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Web3Provider>
+      <ToastContainer />
     </ThemeProvider>
   );
 };

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,7 +69,7 @@ const App = () => {
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </Web3Provider>
-      <ToastContainer />
+      <ToastContainer style={{ top: 100 }} />
     </ThemeProvider>
   );
 };

--- a/client/src/components/organisms/forms/EditArticleForm/index.tsx
+++ b/client/src/components/organisms/forms/EditArticleForm/index.tsx
@@ -5,6 +5,7 @@ import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 import ArticleEditor from "~/components/organisms/ArticleEditor";
 import { Button, Grid } from "@mui/material";
 import ArrowBackIosNewRoundedIcon from "@mui/icons-material/ArrowBackIosNewRounded";
+import { toast } from "react-toastify";
 import { useNavigate } from "react-router-dom";
 
 type editArticleFormProps = {
@@ -36,7 +37,7 @@ const EditArticleForm = ({ articleId }: editArticleFormProps) => {
         }
       } catch (error) {
         console.error(error);
-        alert("記事の取得に失敗しました。");
+        toast.error("記事の取得に失敗しました。");
       }
     })();
   }, [articleId]);
@@ -55,11 +56,13 @@ const EditArticleForm = ({ articleId }: editArticleFormProps) => {
         address: account,
         signature,
       });
+      navigate("/mypage");
+      toast.success("記事が更新されました。");
     } catch (error) {
       console.error(error);
-      alert("記事の更新に失敗しました。");
+      toast.error("記事の更新に失敗しました。");
     }
-  }, [account, articleId, content, title, web3.eth.personal]);
+  }, [account, articleId, content, navigate, title, web3.eth.personal]);
 
   const onChangeTitleInput = useCallback<
     React.ChangeEventHandler<HTMLInputElement>

--- a/client/src/components/organisms/forms/NewArticleForm/index.tsx
+++ b/client/src/components/organisms/forms/NewArticleForm/index.tsx
@@ -9,6 +9,8 @@ import ArrowBackIosNewRoundedIcon from "@mui/icons-material/ArrowBackIosNewRound
 /**
  * 記事の新規作成用のフォーム
  */
+import { toast } from "react-toastify";
+
 const NewArticleForm = () => {
   const [content, setContent] = useState("");
   const [titleInput, setTitleInput] = useState("");
@@ -49,10 +51,11 @@ const NewArticleForm = () => {
         address: account,
         signature: signatureForMint,
       });
-      navigate(`/articles/${id}/edit`);
+      navigate("/mypage");
+      toast.success("記事を作成しました。");
     } catch (error) {
       console.error(error);
-      alert("記事の作成に失敗しました。");
+      toast.error("記事の作成に失敗しました。");
     }
   }, [account, content, navigate, titleInput, web3.eth.personal]);
   return (

--- a/client/src/components/organisms/forms/ResetWalletForm/index.tsx
+++ b/client/src/components/organisms/forms/ResetWalletForm/index.tsx
@@ -8,6 +8,7 @@ import WalletAddressDisplay from "~/components/organisms/WalletAddressDisplay";
 import { Button, Grid } from "@mui/material";
 import Spacer from "~/components/atoms/Spacer";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 /**
  * walletを再設定するためのフォーム
@@ -22,6 +23,7 @@ const ResetWalletForm = () => {
     return walletAddress;
   }, [attributes]);
   const { account } = useWeb3Context();
+  const navigate = useNavigate();
 
   const resetWalletAddress = useCallback(() => {
     user.updateAttributes(
@@ -33,22 +35,25 @@ const ResetWalletForm = () => {
       ],
       (err) => {
         if (err) {
-          alert(err.message || JSON.stringify(err));
+          console.error(err.message || JSON.stringify(err));
+          toast.error("Wallet addressの更新に失敗しました。");
           return;
         }
-        alert("wallet addressの更新に成功しました");
-        window.location.reload();
+        toast.success("Wallet addressの更新に成功しました。");
+        navigate("/reset-wallet", {
+          state: {
+            shouldLoadCurrentUser: true,
+          },
+        });
       }
     );
-  }, [user, walletAddressInput]);
+  }, [navigate, user, walletAddressInput]);
 
   const onChangeWalletAddressInput = useCallback<
     React.ChangeEventHandler<HTMLInputElement>
   >((event) => {
     setWalletAddressInput(event.target.value);
   }, []);
-
-  const navigate = useNavigate();
 
   return (
     <Form>
@@ -113,7 +118,7 @@ const ResetWalletForm = () => {
           <Grid item container xs={2} direction="row-reverse">
             <Button
               onClick={() => {
-                navigate(-1);
+                navigate("/mypage");
               }}
               variant="contained"
               style={{ fontSize: "1.4rem" }}

--- a/client/src/components/organisms/forms/SignInForm/index.tsx
+++ b/client/src/components/organisms/forms/SignInForm/index.tsx
@@ -11,6 +11,8 @@ import Spacer from "~/components/atoms/Spacer";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 import metamaskSvg from "~/assets/metamask.svg";
 import WalletAddressDisplay from "../../WalletAddressDisplay";
+import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
 
 type signInWithPasswordForm = {
   username: string;
@@ -23,6 +25,7 @@ const SignInForm = () => {
     password: "",
   });
   const { account, web3 } = useWeb3Context();
+  const navigate = useNavigate();
 
   const onChangeForm = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
     (event) => {
@@ -47,14 +50,18 @@ const SignInForm = () => {
       event.preventDefault();
       try {
         await signInToCognitoWithPassword(form.username, form.password);
-        alert("サインイン成功");
-        window.location.reload();
+        navigate("/mypage", {
+          state: {
+            shouldLoadCurrentUser: true,
+          },
+        });
+        toast.success("サインインしました。");
       } catch (error) {
         console.error(error);
-        alert("サインイン失敗");
+        toast.error("サインインに失敗しました。");
       }
     },
-    [form.password, form.username]
+    [form.password, form.username, navigate]
   );
 
   const signInWithWallet = useCallback<
@@ -64,14 +71,18 @@ const SignInForm = () => {
       event.preventDefault();
       try {
         await signInToCognitoWithWallet(form.username, web3, account);
-        alert("サインイン成功");
-        window.location.reload();
+        navigate("/mypage", {
+          state: {
+            shouldLoadCurrentUser: true,
+          },
+        });
+        toast.success("サインインしました。");
       } catch (error) {
         console.error(error);
-        alert("サインイン失敗");
+        toast.error("サインインに失敗しました。");
       }
     },
-    [account, form.username, web3]
+    [account, form.username, navigate, web3]
   );
 
   return (

--- a/client/src/components/organisms/forms/SignInForm/index.tsx
+++ b/client/src/components/organisms/forms/SignInForm/index.tsx
@@ -12,7 +12,7 @@ import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 import metamaskSvg from "~/assets/metamask.svg";
 import WalletAddressDisplay from "../../WalletAddressDisplay";
 import { toast } from "react-toastify";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 type signInWithPasswordForm = {
   username: string;
@@ -152,6 +152,15 @@ const SignInForm = () => {
               </Button>
             </Grid>
           </Grid>
+        </Grid>
+        <Grid item container justifyContent="center">
+          <p>
+            まだアカウントを持っていない方は
+            <Link to="/signup" style={{ color: "#000" }}>
+              サインアップ
+            </Link>
+            へ
+          </p>
         </Grid>
       </Grid>
     </Form>

--- a/client/src/components/organisms/forms/SignUpForm/index.tsx
+++ b/client/src/components/organisms/forms/SignUpForm/index.tsx
@@ -16,7 +16,7 @@ import Form from "~/components/atoms/authForm/Form";
 import Spacer from "~/components/atoms/Spacer";
 import WalletAddressDisplay from "~/components/organisms/WalletAddressDisplay";
 import { toast } from "react-toastify";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 /**
  * 参考:
@@ -224,6 +224,15 @@ const SignUpForm = () => {
             </Grid>
           </Grid>
         )}
+        <Grid item container justifyContent="center">
+          <p>
+            すでにアカウントを持っている人は
+            <Link to="/signin" style={{ color: "#000" }}>
+              サインイン
+            </Link>
+            へ
+          </p>
+        </Grid>
       </Grid>
     </Form>
   );

--- a/client/src/components/organisms/forms/SignUpForm/index.tsx
+++ b/client/src/components/organisms/forms/SignUpForm/index.tsx
@@ -15,6 +15,8 @@ import Checkbox from "~/components/atoms/authForm/Checkbox";
 import Form from "~/components/atoms/authForm/Form";
 import Spacer from "~/components/atoms/Spacer";
 import WalletAddressDisplay from "~/components/organisms/WalletAddressDisplay";
+import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
 
 /**
  * 参考:
@@ -49,6 +51,7 @@ const SignUpForm = () => {
   const [hasSignedUp, setHasSignedUp] = useState(false);
   const [code, setCode] = useState("");
   const { account } = useWeb3Context();
+  const navigate = useNavigate();
 
   const onChangeForm = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
     (event) => {
@@ -92,17 +95,18 @@ const SignUpForm = () => {
       event.preventDefault();
       try {
         await signUpToCognito(form);
-        alert("successfully signed up!");
         setHasSignedUp(true);
+        toast.success("登録した電話番号にコードを送信しました。");
       } catch (error) {
+        console.error(error);
         if (error instanceof AxiosError) {
           // TODO: Print errors on each input fields.
           const message = translateSignUpErrorMessage(
             JSON.stringify(error.response?.data)
           );
-          alert(message);
+          toast.error(message);
         } else {
-          alert("sign up failed...");
+          toast.error("サインアップに失敗しました。");
         }
       }
     },
@@ -120,12 +124,13 @@ const SignUpForm = () => {
       event.preventDefault();
       try {
         await confirmSigningUpToCognito(form.username, code);
-        alert("successfully verifyed code!");
+        navigate("/signin");
+        toast.success("認証コードの検証に成功しました。");
       } catch (error) {
-        alert("verification failed...");
+        toast.error("認証コードの検証に失敗しました。");
       }
     },
-    [form, code]
+    [form.username, code, navigate]
   );
 
   return (

--- a/client/src/components/organisms/forms/SignUpForm/index.tsx
+++ b/client/src/components/organisms/forms/SignUpForm/index.tsx
@@ -226,7 +226,7 @@ const SignUpForm = () => {
         )}
         <Grid item container justifyContent="center">
           <p>
-            すでにアカウントを持っている人は
+            すでにアカウントを持っている方は
             <Link to="/signin" style={{ color: "#000" }}>
               サインイン
             </Link>

--- a/client/src/components/organisms/forms/SignUpForm/index.tsx
+++ b/client/src/components/organisms/forms/SignUpForm/index.tsx
@@ -3,6 +3,7 @@ import {
   signUpToCognito,
   SignUpForm,
   confirmSigningUpToCognito,
+  signInToCognitoWithPassword,
 } from "~/apis/cognito";
 import { useWeb3Context } from "~/components/organisms/providers/Web3Provider";
 import PhoneInput from "react-phone-number-input/input";
@@ -124,13 +125,25 @@ const SignUpForm = () => {
       event.preventDefault();
       try {
         await confirmSigningUpToCognito(form.username, code);
-        navigate("/signin");
         toast.success("認証コードの検証に成功しました。");
       } catch (error) {
         toast.error("認証コードの検証に失敗しました。");
+        return;
+      }
+
+      try {
+        await signInToCognitoWithPassword(form.username, form.password);
+        toast.success("サインインしました。");
+        navigate("mypage", {
+          state: {
+            shouldLoadCurrentUser: true,
+          },
+        });
+      } catch (error) {
+        toast.error("サインインに失敗しました。");
       }
     },
-    [form.username, code, navigate]
+    [form.username, form.password, code, navigate]
   );
 
   return (

--- a/client/src/components/organisms/tables/AccountInfoTable/index.tsx
+++ b/client/src/components/organisms/tables/AccountInfoTable/index.tsx
@@ -28,7 +28,7 @@ const AccountInfoTable = () => {
       toast.success("サインアウトしました。");
     } catch (error) {
       console.error(error);
-      toast.error("サインインに失敗しました。");
+      toast.error("サインアウトに失敗しました。");
     }
   }, [navigate, user]);
 

--- a/client/src/components/organisms/tables/AccountInfoTable/index.tsx
+++ b/client/src/components/organisms/tables/AccountInfoTable/index.tsx
@@ -4,6 +4,7 @@ import { signOutFromCognito } from "~/apis/cognito";
 import WalletAddressDisplay from "~/components/organisms/WalletAddressDisplay";
 import { useNavigate } from "react-router-dom";
 import { Button, Grid } from "@mui/material";
+import { toast } from "react-toastify";
 
 const AccountInfoTable = () => {
   const { user, attributes } = useAuthContext();
@@ -16,13 +17,21 @@ const AccountInfoTable = () => {
     )?.Value;
     return [phoneNumber, walletAddress];
   }, [attributes]);
+  const navigate = useNavigate();
 
   const signOut = useCallback(async () => {
-    await signOutFromCognito(user);
-    window.location.reload();
-  }, [user]);
+    try {
+      await signOutFromCognito(user);
+      navigate("/signin", {
+        state: { shouldLoadCurrentUser: true },
+      });
+      toast.success("サインアウトしました。");
+    } catch (error) {
+      console.error(error);
+      toast.error("サインインに失敗しました。");
+    }
+  }, [navigate, user]);
 
-  const navigate = useNavigate();
   return (
     <Grid item container direction="column" spacing={2}>
       <Grid item>


### PR DESCRIPTION
closes #35 
closes #142

- アラートをtoastifyを使ってきれいに表示するようにした
- 画面の自動遷移をいくつかの箇所に実装
  - サインイン成功後にマイページへ
  - サインアップ成功後にサインアップへ
- `サインアップフォーム -> サインインフォーム` `サインインフォーム -> サインアップフォーム`への導線を実装