### PR TITLE
DBで`articles.OriginalAuthorAddress`をユーザIDに置き換える

### DIFF
--- a/server/gateways/api/design/article.go
+++ b/server/gateways/api/design/article.go
@@ -36,6 +36,18 @@ func articleOwnerAddressAttribute(fieldName string) {
 	})
 }
 
+func articleOwnerIdAttribute(fieldName string) {
+	dsl.Attribute(fieldName, dsl.String, func() {
+		dsl.Description("所有者のUserID")
+
+		dsl.Pattern("^[A-Za-z0-9_-]+$")
+		dsl.MinLength(1)
+		dsl.MaxLength(40)
+
+		dsl.Example("exampleId01")
+	})
+}
+
 var articleReadRequest = dsl.Type("ArticleReadRequest", func() {
 	articleIdAttribute("id")
 	dsl.Required("id")
@@ -71,8 +83,9 @@ var articleResult = dsl.ResultType("article-result", "ArticleResult", func() {
 		articleIdAttribute("id")
 		titleAttribute("title")
 		contentAttribute("content")
+		articleOwnerIdAttribute("owner_id")
 		articleOwnerAddressAttribute("owner_address")
-		dsl.Required("id", "title", "content", "owner_address")
+		dsl.Required("id", "title", "content", "owner_id")
 	})
 
 	dsl.View("default", func() {
@@ -81,10 +94,11 @@ var articleResult = dsl.ResultType("article-result", "ArticleResult", func() {
 		dsl.Attribute("content")
 	})
 
-	dsl.View("with-owner-address", func() {
+	dsl.View("with-owner-info", func() {
 		dsl.Attribute("id")
 		dsl.Attribute("title")
 		dsl.Attribute("content")
+		dsl.Attribute("owner_id")
 		dsl.Attribute("owner_address")
 	})
 
@@ -127,7 +141,7 @@ var _ = dsl.Service("articles", func() {
 		dsl.Payload(articleReadRequest)
 
 		dsl.Result(articleResult, func() {
-			dsl.View("with-owner-address")
+			dsl.View("with-owner-info")
 		})
 
 		dsl.HTTP(func() {

--- a/server/gateways/api/design/search.go
+++ b/server/gateways/api/design/search.go
@@ -8,9 +8,11 @@ var searchRequest = dsl.Type("SearchRequest", func() {
 		dsl.Example("Golang+NFT")
 	})
 	dsl.Attribute("owned_by", dsl.String, func() {
-		dsl.Description("記事の所有者。指定がない場合、全ての所有者の記事を検索する。")
-		dsl.Pattern("^0x[a-fA-F0-9]{40}$")
-		dsl.Example(`'0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'`)
+		dsl.Description("記事の所有者のUserID。指定がない場合、全ての所有者の記事を検索する。")
+		dsl.Pattern("^[A-Za-z0-9_-]+$")
+		dsl.MinLength(1)
+		dsl.MaxLength(40)
+		dsl.Example("exampleId01")
 	})
 	dsl.Attribute("sort_by", dsl.String, func() {
 		dsl.Description("記事をソートするkey")
@@ -33,8 +35,9 @@ var searchRequest = dsl.Type("SearchRequest", func() {
 var searchResultEntry = dsl.Type("SearchResultEntry", func() {
 	articleIdAttribute("id")
 	titleAttribute("title")
+	articleOwnerIdAttribute("owner_id")
 	articleOwnerAddressAttribute("owner_address")
-	dsl.Required("id", "title", "owner_address")
+	dsl.Required("id", "title", "owner_id")
 })
 
 var searchResult = dsl.ResultType("SearchResult", func() {

--- a/server/gateways/aws/dynamodb.go
+++ b/server/gateways/aws/dynamodb.go
@@ -2,12 +2,18 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
-var userTableName = "user_to_wallet"
+const (
+	userTableName        = "user_to_wallet"
+	addressToIDIndexName = "wallet_address-index"
+)
 
 type DynamoDBClient struct {
 	*dynamodb.Client
@@ -20,9 +26,9 @@ func NewDynamoDBClient() *DynamoDBClient {
 	})}
 }
 
-func (c *DynamoDBClient) GetAddressByID(userID string) (string, error) {
+func (c *DynamoDBClient) GetAddressByID(userID string) (*common.Address, error) {
 	res, err := c.GetItem(context.Background(), &dynamodb.GetItemInput{
-		TableName: &userTableName,
+		TableName: aws.String(userTableName),
 		Key: map[string]types.AttributeValue{
 			"user_id": &types.AttributeValueMemberS{Value: userID},
 		},
@@ -30,11 +36,38 @@ func (c *DynamoDBClient) GetAddressByID(userID string) (string, error) {
 		ConsistentRead:       aws.Bool(true),
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	address := res.Item["wallet_address"].(*types.AttributeValueMemberS).Value
-	return address, nil
+	if item, ok := res.Item["wallet_address"]; ok {
+		addr := common.HexToAddress(item.(*types.AttributeValueMemberS).Value)
+		return &addr, nil
+	} else {
+		// user_id not found or the user doesn't have a wallet_address
+		return nil, nil
+	}
+}
+
+func (c *DynamoDBClient) GetIDByAddress(walletAddress common.Address) (string, error) {
+	res, err := c.Query(context.Background(), &dynamodb.QueryInput{
+		TableName:              aws.String(userTableName),
+		IndexName:              aws.String(addressToIDIndexName),
+		KeyConditionExpression: aws.String("wallet_address = :wallet_address_value"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":wallet_address_value": &types.AttributeValueMemberS{Value: walletAddress.String()},
+		},
+		Limit:                aws.Int32(1),
+		ProjectionExpression: aws.String("user_id"),
+	})
+	if err != nil {
+		return "", err
+	}
+	if res.Count == 0 {
+		return "", errors.New(fmt.Sprintf("wallet address %s not found", walletAddress))
+	}
+
+	id := res.Items[0]["user_id"].(*types.AttributeValueMemberS).Value
+	return id, nil
 }
 
 func (c *DynamoDBClient) PutUserWallet(userID string, walletAddress string) error {
@@ -43,14 +76,14 @@ func (c *DynamoDBClient) PutUserWallet(userID string, walletAddress string) erro
 			"user_id":        &types.AttributeValueMemberS{Value: userID},
 			"wallet_address": &types.AttributeValueMemberS{Value: walletAddress},
 		},
-		TableName: &userTableName,
+		TableName: aws.String(userTableName),
 	})
 	return err
 }
 
 func (c *DynamoDBClient) DeleteUserWalletByID(userID string) error {
 	_, err := c.DeleteItem(context.Background(), &dynamodb.DeleteItemInput{
-		TableName: &userTableName,
+		TableName: aws.String(userTableName),
 		Key: map[string]types.AttributeValue{
 			"user_id": &types.AttributeValueMemberS{Value: userID},
 		},

--- a/server/gateways/ethereum/client.go
+++ b/server/gateways/ethereum/client.go
@@ -1,6 +1,8 @@
 package ethereum
 
 import (
+	"errors"
+	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -33,16 +35,23 @@ func (c *ContractClient) NewAdminTransactOpts() (*bind.TransactOpts, error) {
 }
 
 // GetOwnerAddressOf loads look for article NFT, and if it exists, it returns its owner.
-// If the article NFT doesn't exist, it returns `target.OriginalAuthorAddress`.
+// If the article NFT doesn't exist, it returns nil.
 func (c *ContractClient) GetOwnerAddressOf(target models.Article) (*common.Address, error) {
-	// TODO: Rename GetOwnerOfArticle to GetOwnerOfArticleToken
-	owner, err := c.GetOwnerOfArticle(&bind.CallOpts{}, target.ID)
-	if err != nil {
-		return nil, err
+	if target.IsTokenized {
+		owner, err := c.GetOwnerOfArticle(&bind.CallOpts{}, target.ID)
+		if err != nil {
+			return nil, err
+		}
+
+		if owner.String() == common.BigToAddress(big.NewInt(0)).String() {
+			return nil, errors.New(fmt.Sprintf(
+				"couldn't find nft for article %s although `isTokenized` is set to true",
+				target.ID,
+			))
+		} else {
+			return &owner, nil
+		}
+	} else {
+		return nil, nil
 	}
-	// TODO: Add Article.IsTokenized to check this before contract call.
-	if owner.String() == common.BigToAddress(big.NewInt(0)).String() {
-		owner = common.HexToAddress(target.OriginalAuthorAddress)
-	}
-	return &owner, nil
 }

--- a/server/main.go
+++ b/server/main.go
@@ -50,8 +50,8 @@ func main() {
 	handler := services.NewHttpHandler()
 	handler.AddService(services.NewArticlesService(db, contract, cognitoClient, dynamoDBClient, *handler), "articles")
 	handler.AddService(services.NewArticlesHtmlService(db, *handler), "articles-html")
-	handler.AddService(services.NewNftsService(db, contract, s3Client, *handler), "nfts")
-	handler.AddService(services.NewSearchService(db, contract, *handler), "search")
+	handler.AddService(services.NewNftsService(db, contract, s3Client, dynamoDBClient, *handler), "nfts")
+	handler.AddService(services.NewSearchService(db, contract, dynamoDBClient, *handler), "search")
 	handler.AddService(services.NewHealthcheckService(db, contract, *handler), "healthcheck")
 
 	logger.Info().Msg("Starting backend server...")

--- a/server/models/article.go
+++ b/server/models/article.go
@@ -7,20 +7,20 @@ import (
 )
 
 type Article struct {
-	ID                    string   `gorm:"primarykey"`
-	Document              Document `gorm:"polymorphic:Owner; polymorphicValue:ARTICLE"`
-	OriginalAuthorAddress string   `gorm:"not null"`
-	IsTokenized           bool     `gorm:"not null"`
+	ID               string   `gorm:"primarykey"`
+	Document         Document `gorm:"polymorphic:Owner; polymorphicValue:ARTICLE"`
+	OriginalAuthorID string   `gorm:"not null"`
+	IsTokenized      bool     `gorm:"not null"`
 }
 
-func NewArticle(title string, content []byte, authorAddress string) *Article {
+func NewArticle(title string, content []byte, authorID string) *Article {
 	id, _ := nanoid.GenerateString(nanoid.DefaultAlphabet, 11)
 	doc := NewDocument(id, ArticleType, title, content)
 	return &Article{
-		ID:                    id,
-		Document:              *doc,
-		OriginalAuthorAddress: authorAddress,
-		IsTokenized:           false,
+		ID:               id,
+		Document:         *doc,
+		OriginalAuthorID: authorID,
+		IsTokenized:      false,
 	}
 }
 

--- a/server/openapi3.yaml
+++ b/server/openapi3.yaml
@@ -121,11 +121,12 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/ReadResponseBodyWithOwnerAddress'
+                                $ref: '#/components/schemas/ReadResponseBodyWithOwnerInfo'
                             example:
                                 content: <h1> Hello World! </h1>
                                 id: exampleId01
                                 owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                                owner_id: exampleId01
                                 title: My Awesome Title
                 "404":
                     description: 'not_found: IDに対応するリソースが見つからなかった場合'
@@ -629,14 +630,16 @@ paths:
                   example: Golang+NFT
                 - name: owned_by
                   in: query
-                  description: 記事の所有者。指定がない場合、全ての所有者の記事を検索する。
+                  description: 記事の所有者のUserID。指定がない場合、全ての所有者の記事を検索する。
                   allowEmptyValue: true
                   schema:
                     type: string
-                    description: 記事の所有者。指定がない場合、全ての所有者の記事を検索する。
-                    example: '''0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'''
-                    pattern: ^0x[a-fA-F0-9]{40}$
-                  example: '''0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'''
+                    description: 記事の所有者のUserID。指定がない場合、全ての所有者の記事を検索する。
+                    example: exampleId01
+                    pattern: ^[A-Za-z0-9_-]+$
+                    minLength: 1
+                    maxLength: 40
+                  example: exampleId01
                 - name: sort_by
                   in: query
                   description: 記事をソートするkey
@@ -684,12 +687,15 @@ paths:
                                 results:
                                     - id: exampleId01
                                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                                      owner_id: exampleId01
                                       title: My Awesome Title
                                     - id: exampleId01
                                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                                      owner_id: exampleId01
                                       title: My Awesome Title
                                     - id: exampleId01
                                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                                      owner_id: exampleId01
                                       title: My Awesome Title
                                 total_count: 18225424149782934695
     /articles/{id}:
@@ -959,7 +965,7 @@ components:
                 - temporary
                 - timeout
                 - fault
-        ReadResponseBodyWithOwnerAddress:
+        ReadResponseBodyWithOwnerInfo:
             type: object
             properties:
                 content:
@@ -978,20 +984,28 @@ components:
                     description: 所有者のウォレットのアドレス
                     example: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
                     pattern: ^0x[a-fA-F0-9]{40}$
+                owner_id:
+                    type: string
+                    description: 所有者のUserID
+                    example: exampleId01
+                    pattern: ^[A-Za-z0-9_-]+$
+                    minLength: 1
+                    maxLength: 40
                 title:
                     type: string
                     example: My Awesome Title
-            description: ReadResponseBody result type (with-owner-address view)
+            description: ReadResponseBody result type (with-owner-info view)
             example:
                 content: <h1> Hello World! </h1>
                 id: exampleId01
                 owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                owner_id: exampleId01
                 title: My Awesome Title
             required:
                 - id
                 - title
                 - content
-                - owner_address
+                - owner_id
         SearchResultEntry:
             type: object
             properties:
@@ -1007,17 +1021,25 @@ components:
                     description: 所有者のウォレットのアドレス
                     example: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
                     pattern: ^0x[a-fA-F0-9]{40}$
+                owner_id:
+                    type: string
+                    description: 所有者のUserID
+                    example: exampleId01
+                    pattern: ^[A-Za-z0-9_-]+$
+                    minLength: 1
+                    maxLength: 40
                 title:
                     type: string
                     example: My Awesome Title
             example:
                 id: exampleId01
                 owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                owner_id: exampleId01
                 title: My Awesome Title
             required:
                 - id
                 - title
-                - owner_address
+                - owner_id
         Searchresult:
             type: object
             properties:
@@ -1029,12 +1051,15 @@ components:
                     example:
                         - id: exampleId01
                           owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                          owner_id: exampleId01
                           title: My Awesome Title
                         - id: exampleId01
                           owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                          owner_id: exampleId01
                           title: My Awesome Title
                         - id: exampleId01
                           owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                          owner_id: exampleId01
                           title: My Awesome Title
                 total_count:
                     type: integer
@@ -1044,12 +1069,15 @@ components:
                 results:
                     - id: exampleId01
                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                      owner_id: exampleId01
                       title: My Awesome Title
                     - id: exampleId01
                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                      owner_id: exampleId01
                       title: My Awesome Title
                     - id: exampleId01
                       owner_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 '
+                      owner_id: exampleId01
                       title: My Awesome Title
                 total_count: 12784667946624386665
             required:

--- a/server/services/articles_test.go
+++ b/server/services/articles_test.go
@@ -27,13 +27,13 @@ func prepareArticlesService(t *testing.T) articleService {
 }
 
 var (
-	article0          = *models.NewArticle("Article0", []byte("<h1> content0 </h1>"), testUsers[0].Address)
-	article1          = *models.NewArticle("Article1", []byte("<div> content1 </div>"), testUsers[0].Address)
+	article0          = *models.NewArticle("Article0", []byte("<h1> content0 </h1>"), testUsers[0].ID)
+	article1          = *models.NewArticle("Article1", []byte("<div> content1 </div>"), testUsers[0].ID)
 	tokenizedArticle0 = models.Article{
-		ID:                    article0.ID,
-		Document:              article0.Document,
-		OriginalAuthorAddress: article0.OriginalAuthorAddress,
-		IsTokenized:           true,
+		ID:               article0.ID,
+		Document:         article0.Document,
+		OriginalAuthorID: article0.OriginalAuthorID,
+		IsTokenized:      true,
 	}
 )
 
@@ -75,7 +75,8 @@ func TestReadArticle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, article0.ID, result.ID)
 		assert.Equal(t, article0.Document.Title, result.Title)
-		assert.Equal(t, article0.OriginalAuthorAddress, result.OwnerAddress)
+		assert.Equal(t, testUsers[0].ID, result.OwnerID)
+		assert.Equal(t, testUsers[0].Address, *result.OwnerAddress)
 		assert.Equal(t, string(article0.Document.Content), result.Content)
 	})
 
@@ -92,7 +93,8 @@ func TestReadArticle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tokenizedArticle0.ID, result.ID)
 		assert.Equal(t, tokenizedArticle0.Document.Title, result.Title)
-		assert.Equal(t, testUsers[1].Address, result.OwnerAddress)
+		assert.Equal(t, testUsers[1].ID, result.OwnerID)
+		assert.Equal(t, testUsers[1].Address, *result.OwnerAddress)
 		assert.Equal(t, string(tokenizedArticle0.Document.Content), result.Content)
 	})
 }

--- a/server/services/nfts_test.go
+++ b/server/services/nfts_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/team-azb/knowtfolio/server/config"
 	"github.com/team-azb/knowtfolio/server/gateways/api/gen/nfts"
+	"github.com/team-azb/knowtfolio/server/gateways/aws"
 	"github.com/team-azb/knowtfolio/server/gateways/ethereum"
 	"github.com/team-azb/knowtfolio/server/models"
 	"io"
@@ -29,9 +30,10 @@ func prepareNftsService(t *testing.T) nftsService {
 	}
 
 	service := nftsService{
-		DB:       initTestDB(t),
-		Contract: initTestContractClient(t),
-		S3Client: s3.NewFromConfig(cfg),
+		DB:             initTestDB(t),
+		Contract:       initTestContractClient(t),
+		S3Client:       s3.NewFromConfig(cfg),
+		DynamoDBClient: aws.NewDynamoDBClient(),
 	}
 
 	return service
@@ -70,7 +72,7 @@ func TestCreateNFTForArticle(t *testing.T) {
 	actualOwner, err := service.Contract.GetOwnerOfArticle(&bind.CallOpts{}, article0.ID)
 	assert.True(t, nftMinted)
 	assert.NoError(t, err)
-	assert.Equal(t, article0.OriginalAuthorAddress, actualOwner.String())
+	assert.Equal(t, testUsers[0].Address, actualOwner.String())
 
 	// Assert metadata existence.
 	getObjOutput, reqErr := service.S3Client.GetObject(context.Background(), &s3.GetObjectInput{

--- a/server/services/search.go
+++ b/server/services/search.go
@@ -44,10 +44,10 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 			return nil, err
 		}
 
-		ownedArticleIds, err := s.Contract.GetArticleIdsOwnedBy(&bind.CallOpts{}, *ownedByAddr)
-		for i, url := range ownedArticleIds {
+		ownedArticleIDs, err := s.Contract.GetArticleIdsOwnedBy(&bind.CallOpts{}, *ownedByAddr)
+		for i, url := range ownedArticleIDs {
 			// TODO: Do this part on the contract side.
-			ownedArticleIds[i] = strings.TrimPrefix(url, "https://knowtfolio.com/nfts/")
+			ownedArticleIDs[i] = strings.TrimPrefix(url, "https://knowtfolio.com/nfts/")
 		}
 
 		if err != nil {
@@ -55,7 +55,7 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 		}
 		ownedByCond := s.DB.
 			// Articles that has been tokenized and whose token is owned by the user.
-			Where(`articles.id IN ?`, ownedArticleIds).
+			Where(`articles.id IN ?`, ownedArticleIDs).
 			// Articles that hasn't been tokenized and is originally created by the user.
 			Or(s.DB.Where(`is_tokenized = 0`).Where(`original_author_id = ?`, *request.OwnedBy))
 		baseQuery = baseQuery.Where(ownedByCond)


### PR DESCRIPTION
Closes #194

バックエンド側でのユーザのメインの識別子を、wallet addressからuser idに変更した
これによりwalletがなくても記事を作成・編集できるようになる