### PR TITLE
`sign_up_form`のvalidationで、パスワードに記号を入れたかどうかが判定されていない問題の解消

### DIFF
--- a/infrastructure/function_scripts/pkg/models/sign_up_form.go
+++ b/infrastructure/function_scripts/pkg/models/sign_up_form.go
@@ -27,7 +27,7 @@ func validateCognitoPassword(fl validator.FieldLevel) bool {
 	containsNumber, _ := regexp.MatchString("[0-9]", val)
 	containsLowercase, _ := regexp.MatchString("[a-z]", val)
 	containsUppercase, _ := regexp.MatchString("[A-Z]", val)
-	containsSpecialCharacter, _ := regexp.MatchString("[^$*.[\\]{}()?\"!@#%&/\\\\,><':;|_~`=+\\-]", val)
+	containsSpecialCharacter, _ := regexp.MatchString("[\\^$*.[\\]{}()?\"!@#%&/\\\\,><':;|_~`=+\\-]", val)
 	containsValidCharactersOnly, _ := regexp.MatchString("^[0-9a-zA-Z^$*.[\\]{}()?\"!@#%&/\\\\,><':;|_~`=+\\-]+$", val)
 	isLengthInRange := 8 <= len(val) && len(val) <= 256
 


### PR DESCRIPTION
closes #218 

原因は記号を含むかどうかのregexが微妙に間違っていて、記号を含まなくてもmatchしてしまっていた点