### PR TITLE
client側でもCognitoのidtokenを使う

### DIFF
--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -1,10 +1,9 @@
 import axios from "axios";
 
 export type postArticleForm = {
-  address: string;
   content: string;
-  signature: string;
   title: string;
+  token: string;
 };
 
 type postArticleResponse = {
@@ -13,12 +12,18 @@ type postArticleResponse = {
   title: string;
 };
 export const postArticle = async (form: postArticleForm) => {
-  const { data } = await axios.post<postArticleResponse>("/api/articles", {
-    address: form.address,
-    content: form.content,
-    signature: form.signature,
-    title: form.title,
-  });
+  const { data } = await axios.post<postArticleResponse>(
+    "/api/articles",
+    {
+      content: form.content,
+      title: form.title,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${form.token}`,
+      },
+    }
+  );
   return data;
 };
 
@@ -26,12 +31,18 @@ export type updateArticleForm = {
   articleId: string;
 } & postArticleForm;
 export const putArticle = async (form: updateArticleForm) => {
-  await axios.put(`/api/articles/${form.articleId}`, {
-    address: form.address,
-    content: form.content,
-    signature: form.signature,
-    title: form.title,
-  });
+  await axios.put(
+    `/api/articles/${form.articleId}`,
+    {
+      content: form.content,
+      title: form.title,
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${form.token}`,
+      },
+    }
+  );
 };
 
 type getArticleResponse = {

--- a/client/src/components/organisms/forms/EditArticleForm/index.tsx
+++ b/client/src/components/organisms/forms/EditArticleForm/index.tsx
@@ -10,6 +10,7 @@ import { Button, Grid } from "@mui/material";
 import ArrowBackIosNewRoundedIcon from "@mui/icons-material/ArrowBackIosNewRounded";
 import { toast } from "react-toastify";
 import { useNavigate } from "react-router-dom";
+import { useAuthContext } from "~/components/organisms/providers/AuthProvider";
 
 type editArticleFormProps = {
   articleId: string;
@@ -27,6 +28,7 @@ const EditArticleForm = ({ articleId }: editArticleFormProps) => {
   >((value) => {
     setContent(value);
   }, []);
+  const { session } = useAuthContext();
   const { isConnectedToMetamask, web3, account } = useWeb3Context();
   const navigate = useNavigate();
 
@@ -48,17 +50,12 @@ const EditArticleForm = ({ articleId }: editArticleFormProps) => {
   const handleUpdate = useCallback(async () => {
     try {
       assertMetamask(isConnectedToMetamask);
-      const signature = await web3.eth.personal.sign(
-        "Update Article",
-        account,
-        ""
-      );
+      const idToken = session.getIdToken().getJwtToken();
       await putArticle({
         articleId: articleId || "",
         title,
         content,
-        address: account,
-        signature,
+        token: idToken,
       });
       navigate("/mypage");
       toast.success("記事が更新されました。");

--- a/client/src/components/organisms/tables/OwnedArticleTable/index.tsx
+++ b/client/src/components/organisms/tables/OwnedArticleTable/index.tsx
@@ -11,7 +11,7 @@ const pageSize = 12;
  * ユーザーが所有している記事を一覧表示できるテーブル
  */
 const OwnedArticleTable = () => {
-  const { userWalletAddress } = useAuthContext();
+  const { user } = useAuthContext();
   const [articles, setArticles] = useState<SearchResultEntry[]>([]);
   const [searchParams, setSearchParams] = useSearchParams();
   const [totalNumOfPage, setTotalNumOfPage] = useState(1);
@@ -24,7 +24,7 @@ const OwnedArticleTable = () => {
   useEffect(() => {
     (async () => {
       const { results, total_count } = await searchArticles({
-        owned_by: userWalletAddress,
+        owned_by: user.getUsername(),
         sort_by: "updated_at",
         page_num: pageNum,
         page_size: pageSize,
@@ -32,7 +32,7 @@ const OwnedArticleTable = () => {
       setArticles(results);
       setTotalNumOfPage(Math.ceil(total_count / pageSize));
     })();
-  }, [pageNum, userWalletAddress]);
+  }, [pageNum, user]);
 
   const changePage = useCallback(
     (_event: React.ChangeEvent<unknown>, page: number) => {


### PR DESCRIPTION
Closes #186 

* 記事の作成・更新で署名の代わりにcognitoのidtokenを使うように
* searchで`owned_by`にアドレスではなくユーザidを指定するように (#194 でserver側が変更された)