### PR TITLE
addressを持っていないユーザがいる場合のsearchとnftsのバグ修正

### DIFF
--- a/server/services/nfts.go
+++ b/server/services/nfts.go
@@ -60,7 +60,7 @@ func (s nftsService) CreateForArticle(ctx context.Context, request *nfts.CreateN
 		if err != nil {
 			return err
 		}
-		if originalAuthorAddress.String() != request.Address {
+		if originalAuthorAddress == nil || originalAuthorAddress.String() != request.Address {
 			msg := fmt.Sprintf("Address %v is not the orignial owner of article %v.", request.Address, target.ID)
 			return nfts.MakeUnauthorized(errors.New(msg))
 		}

--- a/server/services/search.go
+++ b/server/services/search.go
@@ -44,15 +44,19 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 			return nil, err
 		}
 
-		ownedArticleIDs, err := s.Contract.GetArticleIdsOwnedBy(&bind.CallOpts{}, *ownedByAddr)
-		for i, url := range ownedArticleIDs {
-			// TODO: Do this part on the contract side.
-			ownedArticleIDs[i] = strings.TrimPrefix(url, "https://knowtfolio.com/nfts/")
+		var ownedArticleIDs []string
+		if ownedByAddr != nil {
+			ownedArticleIDs, err = s.Contract.GetArticleIdsOwnedBy(&bind.CallOpts{}, *ownedByAddr)
+			if err != nil {
+				return nil, err
+			}
+
+			for i, url := range ownedArticleIDs {
+				// TODO: Do this part on the contract side.
+				ownedArticleIDs[i] = strings.TrimPrefix(url, "https://knowtfolio.com/nfts/")
+			}
 		}
 
-		if err != nil {
-			return nil, err
-		}
 		ownedByCond := s.DB.
 			// Articles that has been tokenized and whose token is owned by the user.
 			Where(`articles.id IN ?`, ownedArticleIDs).


### PR DESCRIPTION
`search`, `nfts`共に`Article.OriginalAuthorID`のユーザがaddressを持っていない場合を想定していない挙動となっており、この場合にpanicしてサーバが死ぬバグがあったので、これを修正した