### PR TITLE
MATCH検索からLIKE検索への切り替え

### DIFF
--- a/server/gateways/database/init.go
+++ b/server/gateways/database/init.go
@@ -51,6 +51,12 @@ func NewConnection(opts ...ConnectionOption) (*gorm.DB, error) {
 	}
 
 	db, err := gorm.Open(gormmysql.Open(cfg.FormatDSN()), &gorm.Config{FullSaveAssociations: true})
+
+	// Output SQL on local execution.
+	if err != nil && config.EnvName == "local" {
+		db = db.Debug()
+	}
+
 	return db, err
 }
 

--- a/server/models/document_test.go
+++ b/server/models/document_test.go
@@ -32,6 +32,14 @@ func TestSetContentIfPresent(t *testing.T) {
 	assert.Equal(t, newContent, string(actual.Content), "Content should be set by SetContentIfPresent.")
 }
 
+func TestReloadRawText(t *testing.T) {
+	actual := Document{Title: "Hello Knowtfolio!", Content: []byte("<div> Hello HTML! </div>")}
+	actual.reloadRawText()
+	expectedRawText := "Hello Knowtfolio!\n Hello HTML! "
+
+	assert.Equal(t, expectedRawText, actual.RawText)
+}
+
 func TestSanitizedContent(t *testing.T) {
 	rawContent := `
 		<div> Hello HTML! </div>

--- a/server/services/search.go
+++ b/server/services/search.go
@@ -65,11 +65,10 @@ func (s searchService) SearchForArticles(_ context.Context, request *search.Sear
 		baseQuery = baseQuery.Where(ownedByCond)
 	}
 	if request.Keywords != nil {
-		keywords := strings.Split(*request.Keywords, "+")
-		for i := range keywords {
-			keywords[i] = fmt.Sprintf(`"%v"`, keywords[i])
+		keywords := strings.Split(*request.Keywords, " ")
+		for _, keyword := range keywords {
+			baseQuery = baseQuery.Where(`raw_text LIKE ?`, fmt.Sprintf("%%%s%%", keyword))
 		}
-		baseQuery = baseQuery.Where(`MATCH(title, raw_text) against(? IN BOOLEAN MODE)`, strings.Join(keywords, " "))
 	}
 
 	// NOTE: Need to call `Session` here to make baseQuery sharable.

--- a/server/services/search_test.go
+++ b/server/services/search_test.go
@@ -80,7 +80,7 @@ func TestSearchForArticles(t *testing.T) {
 	t.Run("WithKeywords", func(t *testing.T) {
 		service := prepareSearchService(t)
 
-		keywords := "reliable+efficient"
+		keywords := "reliable efficient"
 		result, err := service.SearchForArticles(context.Background(), &search.SearchRequest{
 			Keywords: &keywords,
 		})


### PR DESCRIPTION
Closes #184 

効率のためにindexを貼った上で`MATCH`検索をしていたが、 #184 のように`C++`など特殊記号入りの単語が正しく検索できなかったため、素直に`LIKE`検索を`AND`で繋ぐ形とした
これに伴い、`Document.RawText`にタイトルを含ませるようにし、`LIKE`一発で済むようにした

また、ついでにローカルでの実行時にはデバッグ用にDBで実行されたSQLを出力するようにした