### PR TITLE
`make test`のexit codeが、テストが失敗しても0になっていた問題の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ server: goa go-eth-binding $(ARTICLE_PAGE_TEMPLATE)
 	docker-compose up --build server
 
 test: goa go-eth-binding $(ARTICLE_PAGE_TEMPLATE)
-	docker-compose up --build test
+	docker-compose up --build --abort-on-container-exit test
 
 checkfmt-sv: $(SERVER_SRCS)
 	docker-compose run server test -z $$(gofmt -e -l .)


### PR DESCRIPTION
テストが失敗しても、gha上ではsuccessになってしまっていた（致命的）

`docker compose up`の仕様のせいらしい。`--abort-on-container-exit`オプションをつけることで回避