### PR TITLE
golangのcontractのbindingがないために、ghaでの`apply-tf`が失敗する問題の修正

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -73,6 +73,8 @@ jobs:
           echo [knowtfolio] >> infrastructure/.aws/credentials
           echo aws_access_key_id = ${{secrets.AWS_TERRAFORM_USER_ACCESS_KEY}} >> infrastructure/.aws/credentials
           echo aws_secret_access_key = ${{secrets.AWS_TERRAFORM_USER_SECRET_KEY}} >> infrastructure/.aws/credentials
+      - name: generate-eth-binding
+        run: make go-eth-binding
       - name: init-terraform
         run: make init-tf
       - name: terraform-apply

--- a/Makefile
+++ b/Makefile
@@ -27,68 +27,68 @@ HOST_GID = $(shell id -g ${USER})
 .EXPORT_ALL_VARIABLES:
 
 $(CLIENT_NODE_MODULES_DIR): ./client/package.json ./client/Dockerfile $(CONTRACT_JSON_FILE)
-	docker-compose build client
-	docker-compose run client npm install
+	docker compose build client
+	docker compose run client npm install
 	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
 	touch $(CLIENT_NODE_MODULES_DIR)
 
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
-	docker-compose up --build goa
+	docker compose up --build goa
 	cp -f $(GOA_GEN_DIR)/http/openapi3.yaml ./server
 
 $(GO_ETH_BINDING_PATH): $(CONTRACT_ABI_FILE) $(CONTRACT_BIN_FILE)
-	docker-compose up --build go-eth-binding
+	docker compose up --build go-eth-binding
 
 $(BLOCKCHAIN_NODE_MODULES_DIR): ./blockchain/package.json ./blockchain/Dockerfile
-	docker-compose build hardhat
-	docker-compose run hardhat npm --prefix ./blockchain install
+	docker compose build hardhat
+	docker compose run hardhat npm --prefix ./blockchain install
 	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
 	touch $(BLOCKCHAIN_NODE_MODULES_DIR)
 
 $(CONTRACT_JSON_FILE): $(CONTRACT_SOL_FILE) $(BLOCKCHAIN_NODE_MODULES_DIR)
-	docker-compose run hardhat npm --prefix ./blockchain run build
+	docker compose run hardhat npm --prefix ./blockchain run build
 	# To avoid this target from running repeatedly when the json is not updated by the command above.
 	touch $(CONTRACT_JSON_FILE)
 
 # Extract abi field from `$(CONTRACT_JSON_FILE)`.
 $(CONTRACT_ABI_FILE): $(CONTRACT_JSON_FILE)
-	docker-compose run hardhat \
+	docker compose run hardhat \
     	/bin/bash -c "cat $(CONTRACT_JSON_FILE) | jq '.abi' > $(CONTRACT_ABI_FILE)"
 
 # Extract bytecode field from `$(CONTRACT_JSON_FILE)`.
 $(CONTRACT_BIN_FILE): $(CONTRACT_JSON_FILE)
-	docker-compose run hardhat \
+	docker compose run hardhat \
     	/bin/bash -c "cat $(CONTRACT_JSON_FILE) | jq -r '.bytecode' > $(CONTRACT_BIN_FILE)"
 
 $(ARTICLE_PAGE_TEMPLATE): ./client/webpack.config.js $(CLIENT_SRC_DIR) $(CLIENT_NODE_MODULES_DIR)
-	docker-compose run --no-deps client npm run build
-	docker-compose run --no-deps client node dist/insertPageContent.js
+	docker compose run --no-deps client npm run build
+	docker compose run --no-deps client node dist/insertPageContent.js
 	mv -f $(CLIENT_DIST_DIR)/article_template.html $(ARTICLE_PAGE_TEMPLATE)
 
 # Binary file for production server execution
 server/build/server: $(GOA_GEN_DIR) $(GO_ETH_BINDING_PATH)
-	docker-compose run server go build -o build/server
+	docker compose run server go build -o build/server
 
 .PHONY: app client server goa test-sv checkfmt-sv go-eth-binding \
 	init-tf fmt-tf checkfmt-tf plan-tf apply-tf clean
 
 app: goa go-eth-binding $(CLIENT_NODE_MODULES_DIR) $(ARTICLE_PAGE_TEMPLATE)
-	docker-compose up --build client server
+	docker compose up --build client server
 
 
 ### Client ###
 
 client: $(CLIENT_NODE_MODULES_DIR)
-	docker-compose up --build client
+	docker compose up --build client
 
 fmt-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker-compose run client npm run format
+	docker compose run client npm run format
 
 checkfmt-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker-compose run client npx prettier --check 'src/**/*.ts' 'src/**/*.tsx' 'src/**/*.html' 'src/**/*.css' 'webpack.*.js'
+	docker compose run client npx prettier --check 'src/**/*.ts' 'src/**/*.tsx' 'src/**/*.html' 'src/**/*.css' 'webpack.*.js'
 
 lint-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker-compose run client npm run lint
+	docker compose run client npm run lint
 
 
 ### Server ###
@@ -98,31 +98,31 @@ go-eth-binding: $(GO_ETH_BINDING_PATH)
 goa: $(GOA_GEN_DIR)
 
 server: goa go-eth-binding $(ARTICLE_PAGE_TEMPLATE)
-	docker-compose up --build server
+	docker compose up --build server
 
 test: goa go-eth-binding $(ARTICLE_PAGE_TEMPLATE)
-	docker-compose up --build --abort-on-container-exit test
+	docker compose up --build --abort-on-container-exit test
 
 checkfmt-sv: $(SERVER_SRCS)
-	docker-compose run server test -z $$(gofmt -e -l .)
+	docker compose run server test -z $$(gofmt -e -l .)
 
 ### Infrastructure ###
 
 init-tf:
-	docker-compose run terraform init
+	docker compose run terraform init
 
 fmt-tf:
-	docker-compose run terraform fmt
+	docker compose run terraform fmt
 
 checkfmt-tf:
-	docker-compose run terraform fmt -check
+	docker compose run terraform fmt -check
 
 plan-tf:
-	docker-compose run terraform plan
+	docker compose run terraform plan
 
 apply-tf: go-eth-binding
-	docker-compose run terraform apply
+	docker compose run terraform apply
 
 clean:
 	rm -rf $(GOA_GEN_DIR) $(HARDHAT_BUILD_DIRS) $(GO_ETH_BINDING_PATH) $(BLOCKCHAIN_NODE_MODULES_DIR) $(CLIENT_DIST_DIR) $(CLIENT_NODE_MODULES_DIR)
-	docker-compose down
+	docker compose down

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ HOST_GID = $(shell id -g ${USER})
 $(CLIENT_NODE_MODULES_DIR): ./client/package.json ./client/Dockerfile $(CONTRACT_JSON_FILE)
 	docker-compose build client
 	docker-compose run client npm install
+	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
+	touch $(CLIENT_NODE_MODULES_DIR)
 
 $(CLIENT_DIST_DIR): ./client/webpack.config.js $(CLIENT_NODE_MODULES_DIR) $(CLIENT_SRC_DIR)
 	docker-compose run client npm run build
@@ -44,9 +46,13 @@ $(GO_ETH_BINDING_PATH): $(CONTRACT_ABI_FILE) $(CONTRACT_BIN_FILE)
 $(BLOCKCHAIN_NODE_MODULES_DIR): ./blockchain/package.json ./blockchain/Dockerfile
 	docker-compose build hardhat
 	docker-compose run hardhat npm --prefix ./blockchain install
+	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
+	touch $(BLOCKCHAIN_NODE_MODULES_DIR)
 
 $(CONTRACT_JSON_FILE): $(CONTRACT_SOL_FILE) $(BLOCKCHAIN_NODE_MODULES_DIR)
 	docker-compose run hardhat npm --prefix ./blockchain run build
+	# To avoid this target from running repeatedly when the json is not updated by the command above.
+	touch $(CONTRACT_JSON_FILE)
 
 # Extract abi field from `$(CONTRACT_JSON_FILE)`.
 $(CONTRACT_ABI_FILE): $(CONTRACT_JSON_FILE)

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ checkfmt-tf:
 plan-tf:
 	docker-compose run terraform plan
 
-apply-tf:
+apply-tf: go-eth-binding
 	docker-compose run terraform apply
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ HOST_GID = $(shell id -g ${USER})
 
 $(CLIENT_NODE_MODULES_DIR): ./client/package.json ./client/Dockerfile $(CONTRACT_JSON_FILE)
 	docker compose build client
-	docker compose run client npm install
+	docker compose run --rm client npm install
 	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
 	touch $(CLIENT_NODE_MODULES_DIR)
 
@@ -41,33 +41,33 @@ $(GO_ETH_BINDING_PATH): $(CONTRACT_ABI_FILE) $(CONTRACT_BIN_FILE)
 
 $(BLOCKCHAIN_NODE_MODULES_DIR): ./blockchain/package.json ./blockchain/Dockerfile
 	docker compose build hardhat
-	docker compose run hardhat npm --prefix ./blockchain install
+	docker compose run --rm hardhat npm --prefix ./blockchain install
 	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
 	touch $(BLOCKCHAIN_NODE_MODULES_DIR)
 
 $(CONTRACT_JSON_FILE): $(CONTRACT_SOL_FILE) $(BLOCKCHAIN_NODE_MODULES_DIR)
-	docker compose run hardhat npm --prefix ./blockchain run build
+	docker compose run --rm hardhat npm --prefix ./blockchain run build
 	# To avoid this target from running repeatedly when the json is not updated by the command above.
 	touch $(CONTRACT_JSON_FILE)
 
 # Extract abi field from `$(CONTRACT_JSON_FILE)`.
 $(CONTRACT_ABI_FILE): $(CONTRACT_JSON_FILE)
-	docker compose run hardhat \
+	docker compose run --rm hardhat \
     	/bin/bash -c "cat $(CONTRACT_JSON_FILE) | jq '.abi' > $(CONTRACT_ABI_FILE)"
 
 # Extract bytecode field from `$(CONTRACT_JSON_FILE)`.
 $(CONTRACT_BIN_FILE): $(CONTRACT_JSON_FILE)
-	docker compose run hardhat \
+	docker compose run --rm hardhat \
     	/bin/bash -c "cat $(CONTRACT_JSON_FILE) | jq -r '.bytecode' > $(CONTRACT_BIN_FILE)"
 
 $(ARTICLE_PAGE_TEMPLATE): ./client/webpack.config.js $(CLIENT_SRC_DIR) $(CLIENT_NODE_MODULES_DIR)
-	docker compose run --no-deps client npm run build
-	docker compose run --no-deps client node dist/insertPageContent.js
+	docker compose run --rm --no-deps client npm run build
+	docker compose run --rm --no-deps client node dist/insertPageContent.js
 	mv -f $(CLIENT_DIST_DIR)/article_template.html $(ARTICLE_PAGE_TEMPLATE)
 
 # Binary file for production server execution
 server/build/server: $(GOA_GEN_DIR) $(GO_ETH_BINDING_PATH)
-	docker compose run server go build -o build/server
+	docker compose run --rm server go build -o build/server
 
 .PHONY: app client server goa test-sv checkfmt-sv go-eth-binding \
 	init-tf fmt-tf checkfmt-tf plan-tf apply-tf clean
@@ -82,13 +82,13 @@ client: $(CLIENT_NODE_MODULES_DIR)
 	docker compose up --build client
 
 fmt-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker compose run client npm run format
+	docker compose run --rm client npm run format
 
 checkfmt-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker compose run client npx prettier --check 'src/**/*.ts' 'src/**/*.tsx' 'src/**/*.html' 'src/**/*.css' 'webpack.*.js'
+	docker compose run --rm client npx prettier --check 'src/**/*.ts' 'src/**/*.tsx' 'src/**/*.html' 'src/**/*.css' 'webpack.*.js'
 
 lint-cl: $(CLIENT_NODE_MODULES_DIR)
-	docker compose run client npm run lint
+	docker compose run --rm client npm run lint
 
 
 ### Server ###
@@ -104,24 +104,24 @@ test: goa go-eth-binding $(ARTICLE_PAGE_TEMPLATE)
 	docker compose up --build --abort-on-container-exit test
 
 checkfmt-sv: $(SERVER_SRCS)
-	docker compose run server test -z $$(gofmt -e -l .)
+	docker compose run --rm server test -z $$(gofmt -e -l .)
 
 ### Infrastructure ###
 
 init-tf:
-	docker compose run terraform init
+	docker compose run --rm terraform init
 
 fmt-tf:
-	docker compose run terraform fmt
+	docker compose run --rm terraform fmt
 
 checkfmt-tf:
-	docker compose run terraform fmt -check
+	docker compose run --rm terraform fmt -check
 
 plan-tf:
-	docker compose run terraform plan
+	docker compose run --rm terraform plan
 
 apply-tf: go-eth-binding
-	docker compose run terraform apply
+	docker compose run --rm terraform apply
 
 clean:
 	rm -rf $(GOA_GEN_DIR) $(HARDHAT_BUILD_DIRS) $(GO_ETH_BINDING_PATH) $(BLOCKCHAIN_NODE_MODULES_DIR) $(CLIENT_DIST_DIR) $(CLIENT_NODE_MODULES_DIR)


### PR DESCRIPTION
ghaの`infrastructure deploy`は、lambdaのコンパイル時にcontractのbinding(`server/gateways/ethereum/binding.go`に依存するが、ghaのjob実行環境ではこれが生成されていないので失敗していた。
そこで、Makefileの`apply-tf`ターゲットを`go-eth-binding`に依存するようにし（ fc127939fa189db6de9575be9d0d8fc7398c37fc ）、さらに`infrastructure deploy`においても`terraform apply`の前で`make go-eth-binding`するようにした（ a3c832204a2a5112986fd17f4297af3377dbcabc ）。

ついでにMakefileを以下のように修正した
* 6ddb9dbaf94cbce53103800d6a27e3e20617129f コンパイル系のコマンドで、何もしなくていい（ソースが変わっていないなど）時に、生成するはずのファイルのタイムスタンプが更新されず、makeで毎回コンパイルが呼ばれてしまう問題があった。何もしなくていい時でも`touch`をつかってタイムスタンプだけは更新するようにした。
* 50a9c63c9fe08b3178f0144517e52a4bffe807fa `docker-compose`ではなく`docker compose`を使うようにした
* 6c505bffa4b22e48c15dce8b87bfa7b6208f9fce `docker compose run`の時に毎回コンテナが残って、気づいた時にはたくさん残骸が残っているのを解消するために、`--rm`オプションを追加


**※ merge後 `make clean` 推奨**