### PR TITLE
アドレス登録時以外の全ての署名でnonceを使用する

### DIFF
--- a/client/src/apis/dynamodb.ts
+++ b/client/src/apis/dynamodb.ts
@@ -71,10 +71,8 @@ export const fetchNonce = async (client: DynamoDBClient, userId: string) => {
   if (value) {
     return value;
   } else {
-    JSON.stringify(params);
-    console.log(
+    throw new Error(
       `value not found ${JSON.stringify(params)} ${JSON.stringify(resp)}`
     );
-    return "";
   }
 };

--- a/client/src/apis/dynamodb.ts
+++ b/client/src/apis/dynamodb.ts
@@ -48,5 +48,33 @@ export const fetchWalletAddress = async (
   };
   const command = new GetItemCommand(params);
   const resp = await client.send(command);
-  return resp.Item?.wallet_address.S;
+  return resp.Item?.wallet_address?.S;
+};
+
+/**
+ * userIdからnonceを取得する
+ * @param client dynamodbクライアント
+ * @param userId ユーザーid
+ * @returns nonce
+ */
+export const fetchNonce = async (client: DynamoDBClient, userId: string) => {
+  const params: GetItemCommandInput = {
+    TableName: "knowtfolio",
+    Key: {
+      type: { S: "user_id_to_nonce" },
+      key: { S: userId },
+    },
+  };
+  const command = new GetItemCommand(params);
+  const resp = await client.send(command);
+  const value = resp.Item?.value?.S;
+  if (value) {
+    return value;
+  } else {
+    JSON.stringify(params);
+    console.log(
+      `value not found ${JSON.stringify(params)} ${JSON.stringify(resp)}`
+    );
+    return "";
+  }
 };

--- a/client/src/apis/knowtfolio.ts
+++ b/client/src/apis/knowtfolio.ts
@@ -94,3 +94,7 @@ export const searchArticles = async (queryParams: searchQuery = {}) => {
   });
   return data;
 };
+
+export const generateSignData = (message: string, nonce: string) => {
+  return `${message}\n(nonce: ${nonce})`;
+};

--- a/client/src/components/organisms/forms/NewArticleForm/index.tsx
+++ b/client/src/components/organisms/forms/NewArticleForm/index.tsx
@@ -1,6 +1,10 @@
 import { Editor as TinyMCEEditor } from "tinymce";
 import { useCallback, useState } from "react";
-import { mintArticleNft, postArticle } from "~/apis/knowtfolio";
+import {
+  generateSignData,
+  mintArticleNft,
+  postArticle,
+} from "~/apis/knowtfolio";
 import { useNavigate } from "react-router-dom";
 import {
   assertMetamask,
@@ -12,6 +16,7 @@ import ArrowBackIosNewRoundedIcon from "@mui/icons-material/ArrowBackIosNewRound
 import { toast } from "react-toastify";
 import RequireWeb3Wrapper from "~/components/organisms/RequireWeb3Wrapper";
 import { useAuthContext } from "~/components/organisms/providers/AuthProvider";
+import { fetchNonce, initDynamodbClient } from "~/apis/dynamodb";
 
 /**
  * 記事の新規作成用のフォーム
@@ -27,6 +32,7 @@ const NewArticleForm = () => {
     setContent(value);
   }, []);
   const navigate = useNavigate();
+  const dynamodbClient = initDynamodbClient(session.getIdToken().getJwtToken());
 
   const onChangeTitleInput = useCallback<
     React.ChangeEventHandler<HTMLInputElement>
@@ -44,8 +50,10 @@ const NewArticleForm = () => {
       });
 
       assertMetamask(isConnectedToMetamask);
+
+      const nonce = await fetchNonce(dynamodbClient, user.getUsername());
       const signatureForMint = await web3.eth.personal.sign(
-        "Mint NFT",
+        generateSignData("Mint NFT", nonce),
         account,
         ""
       );

--- a/client/src/components/organisms/forms/RegisterWalletForm/index.tsx
+++ b/client/src/components/organisms/forms/RegisterWalletForm/index.tsx
@@ -43,7 +43,7 @@ const RegisteredWalletAddressMessage = () => {
         </Grid>
         <Grid item xs={9.5}>
           <WalletAddressDisplay
-            address={userWalletAddress?}
+            address={userWalletAddress!}
             shouldTruncate={false}
           />
         </Grid>

--- a/client/src/components/organisms/forms/RegisterWalletForm/index.tsx
+++ b/client/src/components/organisms/forms/RegisterWalletForm/index.tsx
@@ -13,6 +13,7 @@ import { postWalletAddress } from "~/apis/lambda";
 import { noteOnWalletAddress } from "~/components/organisms/forms/SignUpForm";
 import RequireWeb3Wrapper from "~/components/organisms/RequireWeb3Wrapper";
 import { toast } from "react-toastify";
+import { initDynamodbClient } from "~/apis/dynamodb";
 
 /**
  * wallet addressがすでに登録されていた場合に表示するメッセージ
@@ -42,7 +43,7 @@ const RegisteredWalletAddressMessage = () => {
         </Grid>
         <Grid item xs={9.5}>
           <WalletAddressDisplay
-            address={userWalletAddress}
+            address={userWalletAddress?}
             shouldTruncate={false}
           />
         </Grid>
@@ -66,13 +67,17 @@ const RegisteredWalletAddressMessage = () => {
  * walletを登録するフォームの本体
  */
 const RegisterWalletFormContent = () => {
-  const { user } = useAuthContext();
+  const { user, session } = useAuthContext();
   const { isConnectedToMetamask, account, web3 } = useWeb3Context();
   const navigate = useNavigate();
+
+  const dynamodbClient = initDynamodbClient(session.getIdToken().getJwtToken());
 
   const registerWalletAddress = useCallback(async () => {
     assertMetamask(isConnectedToMetamask);
     const signature = await web3.eth.personal.sign(
+      // Since the user doesn't have nonce at this point, there will be no nonce added to the message.
+      // Nonce is generated as a result of this post_wallet_address call.
       "Register wallet address",
       account,
       ""

--- a/infrastructure/function_scripts/cmd/create_auth_challenge/main.go
+++ b/infrastructure/function_scripts/cmd/create_auth_challenge/main.go
@@ -1,25 +1,23 @@
 package main
 
 import (
-	"crypto/rand"
 	"fmt"
-
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/team-azb/knowtfolio/server/gateways/ethereum"
 )
 
 func handler(event *events.CognitoEventUserPoolsCreateAuthChallenge) (*events.CognitoEventUserPoolsCreateAuthChallenge, error) {
 	defer fmt.Printf("Create Auth Challenge: %+v\n", event)
 
-	nonceBytes := make([]byte, 32)
-	_, err := rand.Read(nonceBytes)
+	message := "Sign in to Knowtfolio."
+	nonce, err := ethereum.GenerateNonce()
 	if err != nil {
 		return nil, fmt.Errorf("could not generate nonce")
 	}
-
-	signMessage := fmt.Sprintf("Sign in to Knowtfolio.\n(nonce: %x)", nonceBytes)
-	event.Response.PublicChallengeParameters = map[string]string{"sign_message": signMessage}
-	event.Response.PrivateChallengeParameters = map[string]string{"sign_message": signMessage}
+	signData := ethereum.GenerateSignData(message, nonce)
+	event.Response.PublicChallengeParameters = map[string]string{"sign_message": signData}
+	event.Response.PrivateChallengeParameters = map[string]string{"message": message, "nonce": nonce.Hex()}
 
 	return event, nil
 }

--- a/infrastructure/function_scripts/cmd/verify_auth_challenge_response/main.go
+++ b/infrastructure/function_scripts/cmd/verify_auth_challenge_response/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/team-azb/knowtfolio/server/gateways/aws"
 	"github.com/team-azb/knowtfolio/server/gateways/ethereum"
 
@@ -21,9 +22,11 @@ func handler(_ context.Context, event *events.CognitoEventUserPoolsVerifyAuthCha
 	}
 
 	sign := event.Request.ChallengeAnswer.(string)
-	signedData := event.Request.PrivateChallengeParameters["sign_message"]
+	message := event.Request.PrivateChallengeParameters["message"]
+	nonceStr := event.Request.PrivateChallengeParameters["nonce"]
 
-	err = ethereum.VerifySignature(address.String(), sign, signedData)
+	nonce := common.HexToHash(nonceStr)
+	err = ethereum.VerifySignature(address.String(), sign, message, &nonce)
 	if err == nil {
 		event.Response = events.CognitoEventUserPoolsVerifyAuthChallengeResponse{AnswerCorrect: true}
 	}

--- a/infrastructure/function_scripts/pkg/models/post_wallet_address_request.go
+++ b/infrastructure/function_scripts/pkg/models/post_wallet_address_request.go
@@ -11,15 +11,10 @@ type PostWalletAddressRequest struct {
 }
 
 func (p *PostWalletAddressRequest) ValidationInfo() (EthSignatureValidationInfo, error) {
-	nonce, err := dynamoDB.GetNonceByID(p.UserID)
-	if err != nil {
-		return EthSignatureValidationInfo{}, err
-	}
-
 	return EthSignatureValidationInfo{
 		Address:            common.HexToAddress(p.WalletAddress),
 		Message:            "Register wallet address",
-		Nonce:              nonce,
+		Nonce:              nil,
 		Signature:          p.Signature,
 		SignatureFieldName: "Signature",
 	}, nil

--- a/infrastructure/function_scripts/pkg/models/post_wallet_address_request.go
+++ b/infrastructure/function_scripts/pkg/models/post_wallet_address_request.go
@@ -1,7 +1,26 @@
 package models
 
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
 type PostWalletAddressRequest struct {
 	UserID        string `json:"user_id" validate:"required"`
 	WalletAddress string `json:"wallet_address" validate:"required,eth_addr"`
-	Signature     string `json:"signature" validate:"required,eth_sign_addr=WalletAddress"`
+	Signature     string `json:"signature" validate:"required"`
+}
+
+func (p *PostWalletAddressRequest) ValidationInfo() (EthSignatureValidationInfo, error) {
+	nonce, err := dynamoDB.GetNonceByID(p.UserID)
+	if err != nil {
+		return EthSignatureValidationInfo{}, err
+	}
+
+	return EthSignatureValidationInfo{
+		Address:            common.HexToAddress(p.WalletAddress),
+		Message:            "Register wallet address",
+		Nonce:              nonce,
+		Signature:          p.Signature,
+		SignatureFieldName: "Signature",
+	}, nil
 }

--- a/server/gateways/aws/dynamodb.go
+++ b/server/gateways/aws/dynamodb.go
@@ -50,6 +50,15 @@ func (c *DynamoDBClient) GetAddressByID(userID string) (*common.Address, error) 
 	return &addr, nil
 }
 
+func (c *DynamoDBClient) GetNonceByID(userID string) (*common.Hash, error) {
+	addrStr, err := c.getValue(userIDToNonceType, userID)
+	if err != nil {
+		return nil, err
+	}
+	nonce := common.HexToHash(addrStr)
+	return &nonce, nil
+}
+
 // GetAndReplaceNonceByID gets the current nonce and then replace it with a newly generated one.
 // This can be done by a single PutItem call with ReturnValues set to ALL_OLD.
 func (c *DynamoDBClient) GetAndReplaceNonceByID(userID string) (*common.Hash, error) {

--- a/server/gateways/aws/dynamodb.go
+++ b/server/gateways/aws/dynamodb.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"crypto/rand"
 	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/smithy-go"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/team-azb/knowtfolio/server/gateways/ethereum"
 )
 
 const tableName = "knowtfolio"
@@ -50,8 +50,38 @@ func (c *DynamoDBClient) GetAddressByID(userID string) (*common.Address, error) 
 	return &addr, nil
 }
 
-func (c *DynamoDBClient) GetNonceByID(userID string) (string, error) {
-	return c.getValue(userIDToNonceType, userID)
+// GetAndReplaceNonceByID gets the current nonce and then replace it with a newly generated one.
+// This can be done by a single PutItem call with ReturnValues set to ALL_OLD.
+func (c *DynamoDBClient) GetAndReplaceNonceByID(userID string) (*common.Hash, error) {
+	nonce, err := ethereum.GenerateNonce()
+	if err != nil {
+		return nil, &smithy.GenericAPIError{
+			Code:    NonceGenerationFailedCode,
+			Message: err.Error(),
+			Fault:   smithy.FaultServer,
+		}
+	}
+
+	res, err := c.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]types.AttributeValue{
+			"type":  &types.AttributeValueMemberS{Value: string(userIDToNonceType)},
+			"key":   &types.AttributeValueMemberS{Value: userID},
+			"value": &types.AttributeValueMemberS{Value: nonce.Hex()},
+		},
+		ReturnValues: types.ReturnValueAllOld,
+	})
+
+	if val, ok := res.Attributes["value"]; ok {
+		oldNonce := common.HexToHash(val.(*types.AttributeValueMemberS).Value)
+		return &oldNonce, nil
+	} else {
+		return nil, &smithy.GenericAPIError{
+			Code:    ValueFieldNotFoundCode,
+			Message: fmt.Sprintf("`value` field for %s/%s not found", userIDToNonceType, userID),
+			Fault:   smithy.FaultServer,
+		}
+	}
 }
 
 func (c *DynamoDBClient) GetIDByAddress(walletAddress common.Address) (string, error) {
@@ -59,9 +89,13 @@ func (c *DynamoDBClient) GetIDByAddress(walletAddress common.Address) (string, e
 }
 
 func (c *DynamoDBClient) GenerateAndPutNonce(userID string) error {
-	nonce, err := generateNonce()
+	nonce, err := ethereum.GenerateNonce()
 	if err != nil {
-		return err
+		return &smithy.GenericAPIError{
+			Code:    NonceGenerationFailedCode,
+			Message: err.Error(),
+			Fault:   smithy.FaultServer,
+		}
 	}
 
 	_, err = c.PutItem(context.Background(), &dynamodb.PutItemInput{
@@ -69,8 +103,9 @@ func (c *DynamoDBClient) GenerateAndPutNonce(userID string) error {
 		Item: map[string]types.AttributeValue{
 			"type":  &types.AttributeValueMemberS{Value: string(userIDToNonceType)},
 			"key":   &types.AttributeValueMemberS{Value: userID},
-			"value": &types.AttributeValueMemberS{Value: nonce},
+			"value": &types.AttributeValueMemberS{Value: nonce.Hex()},
 		},
+		ReturnValues: types.ReturnValueAllOld,
 	})
 	return err
 }
@@ -96,15 +131,19 @@ func (c *DynamoDBClient) PutUserWallet(userID string, walletAddress string) erro
 		}
 	}
 
-	nonce, err := generateNonce()
+	nonce, err := ethereum.GenerateNonce()
 	if err != nil {
-		return err
+		return &smithy.GenericAPIError{
+			Code:    NonceGenerationFailedCode,
+			Message: err.Error(),
+			Fault:   smithy.FaultServer,
+		}
 	}
 
 	_, err = c.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
 		TransactItems: []types.TransactWriteItem{
 			keyValueToItem(userIDToWalletAddressType, userID, walletAddress),
-			keyValueToItem(userIDToNonceType, userID, nonce),
+			keyValueToItem(userIDToNonceType, userID, nonce.Hex()),
 			keyValueToItem(walletAddressToUserIDType, walletAddress, userID),
 		},
 	})
@@ -202,17 +241,4 @@ func (c *DynamoDBClient) getValue(kvType KeyValueType, key string) (string, erro
 			Fault:   smithy.FaultServer,
 		}
 	}
-}
-
-func generateNonce() (string, error) {
-	nonceBytes := make([]byte, 32)
-	_, err := rand.Read(nonceBytes)
-	if err != nil {
-		return "", &smithy.GenericAPIError{
-			Code:    NonceGenerationFailedCode,
-			Message: err.Error(),
-			Fault:   smithy.FaultServer,
-		}
-	}
-	return fmt.Sprintf("%x", nonceBytes), nil
 }

--- a/server/services/articles_test.go
+++ b/server/services/articles_test.go
@@ -76,7 +76,7 @@ func TestReadArticle(t *testing.T) {
 		assert.Equal(t, article0.ID, result.ID)
 		assert.Equal(t, article0.Document.Title, result.Title)
 		assert.Equal(t, testUsers[0].ID, result.OwnerID)
-		assert.Equal(t, testUsers[0].Address, *result.OwnerAddress)
+		assert.Equal(t, testUsers[0].Address(), *result.OwnerAddress)
 		assert.Equal(t, string(article0.Document.Content), result.Content)
 	})
 
@@ -85,7 +85,7 @@ func TestReadArticle(t *testing.T) {
 
 		// Article0 here is created by user0 and currently owned by user1.
 		service.DB.Create(&tokenizedArticle0)
-		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[1].Address)
+		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[1].Address())
 
 		result, err := service.Read(context.Background(), &articles.ArticleReadRequest{ID: tokenizedArticle0.ID})
 
@@ -94,7 +94,7 @@ func TestReadArticle(t *testing.T) {
 		assert.Equal(t, tokenizedArticle0.ID, result.ID)
 		assert.Equal(t, tokenizedArticle0.Document.Title, result.Title)
 		assert.Equal(t, testUsers[1].ID, result.OwnerID)
-		assert.Equal(t, testUsers[1].Address, *result.OwnerAddress)
+		assert.Equal(t, testUsers[1].Address(), *result.OwnerAddress)
 		assert.Equal(t, string(tokenizedArticle0.Document.Content), result.Content)
 	})
 }
@@ -120,7 +120,7 @@ func TestUpdateArticle(t *testing.T) {
 
 		// Create article and the corresponding NFT.
 		service.DB.Create(&tokenizedArticle0)
-		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[0].Address)
+		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[0].Address())
 
 		// Send update request
 		result, err := service.Update(testUsers[0].GetUserIDContext(), &updateRequestByUser0)
@@ -162,7 +162,7 @@ func TestUpdateArticle(t *testing.T) {
 
 		// Create article and the corresponding NFT.
 		service.DB.Create(&tokenizedArticle0)
-		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[0].Address)
+		mintNFTOfArticle0AndWait(t, service.Contract, testUsers[0].Address())
 
 		// Send update request
 		_, err := service.Update(testUsers[1].GetUserIDContext(), &updateRequestByUser1)

--- a/server/services/nfts_test.go
+++ b/server/services/nfts_test.go
@@ -39,22 +39,18 @@ func prepareNftsService(t *testing.T) nftsService {
 	return service
 }
 
-var (
-	user0MintNFTSign = "0xae7675c53b24e2612b9dce083901989ed5485b77d16f7852013757c7f034c76807d7348655db3783a58319c04d1bf958d21c3cb849922abe4cc2c2badfac4b1b00"
-)
-
 func TestCreateNFTForArticle(t *testing.T) {
 	service := prepareNftsService(t)
 
 	service.DB.Create(&article0)
 
-	transactionLock[testUsers[0].Address].Lock()
+	transactionLock[testUsers[0].Address()].Lock()
 	result, err := service.CreateForArticle(context.Background(), &nfts.CreateNftForArticleRequest{
 		ArticleID: article0.ID,
-		Address:   testUsers[0].Address,
-		Signature: user0MintNFTSign,
+		Address:   testUsers[0].Address(),
+		Signature: testUsers[0].GenerateSignature(config.SignData["CreateNFT"]),
 	})
-	transactionLock[testUsers[0].Address].Unlock()
+	transactionLock[testUsers[0].Address()].Unlock()
 	assert.NoError(t, err)
 
 	// Remove s3 object after the test is done.
@@ -72,7 +68,7 @@ func TestCreateNFTForArticle(t *testing.T) {
 	actualOwner, err := service.Contract.GetOwnerOfArticle(&bind.CallOpts{}, article0.ID)
 	assert.True(t, nftMinted)
 	assert.NoError(t, err)
-	assert.Equal(t, testUsers[0].Address, actualOwner.String())
+	assert.Equal(t, testUsers[0].Address(), actualOwner.String())
 
 	// Assert metadata existence.
 	getObjOutput, reqErr := service.S3Client.GetObject(context.Background(), &s3.GetObjectInput{

--- a/server/services/search_test.go
+++ b/server/services/search_test.go
@@ -23,7 +23,8 @@ var (
 
 var (
 	createEntry = func(article *models.Article, owner *testUser) search.SearchResultEntry {
-		return search.SearchResultEntry{ID: article.ID, Title: article.Document.Title, OwnerID: owner.ID, OwnerAddress: &owner.Address}
+		ownerAddress := owner.Address()
+		return search.SearchResultEntry{ID: article.ID, Title: article.Document.Title, OwnerID: owner.ID, OwnerAddress: &ownerAddress}
 	}
 	goEntry = createEntry(goArticle, &testUsers[0])
 	rsEntry = createEntry(rsArticle, &testUsers[1])
@@ -58,10 +59,10 @@ func prepareSearchService(t *testing.T) searchService {
 	}
 
 	// Mint NFTs for the target articles.
-	err0 := tokenizeTestTargetArticle(service.Contract, goArticle, testUsers[0].Address)
-	err1 := tokenizeTestTargetArticle(service.Contract, rsArticle, testUsers[1].Address)
-	err2 := tokenizeTestTargetArticle(service.Contract, ktArticle, testUsers[1].Address)
-	err3 := tokenizeTestTargetArticle(service.Contract, jsArticle, testUsers[0].Address)
+	err0 := tokenizeTestTargetArticle(service.Contract, goArticle, testUsers[0].Address())
+	err1 := tokenizeTestTargetArticle(service.Contract, rsArticle, testUsers[1].Address())
+	err2 := tokenizeTestTargetArticle(service.Contract, ktArticle, testUsers[1].Address())
+	err3 := tokenizeTestTargetArticle(service.Contract, jsArticle, testUsers[0].Address())
 	err := multierr.Combine(err0, err1, err2, err3)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
アドレス登録（`post_wallet_address`）時はnonceが生成されていない& どのみち一度しかできない操作なので、nonceなしの署名のままにしてある