### PR TITLE
ghaで出ていたエラーを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ $(CLIENT_NODE_MODULES_DIR): ./client/package.json ./client/Dockerfile $(CONTRACT
 	# To avoid this target from running repeatedly when the `node_modules` dir is not updated by the command above.
 	touch $(CLIENT_NODE_MODULES_DIR)
 
+# This target is used by the `client test` gha workflow.
+$(CLIENT_DIST_DIR): ./client/webpack.config.js $(CLIENT_NODE_MODULES_DIR) $(CLIENT_SRC_DIR)
+	docker-compose run client npm run build
+
 $(GOA_GEN_DIR): $(GOA_DESIGN_DIR) $(GOA_DOCKER_FILE) ./server/go.mod
 	docker compose up --build goa
 	cp -f $(GOA_GEN_DIR)/http/openapi3.yaml ./server

--- a/server/goa.Dockerfile
+++ b/server/goa.Dockerfile
@@ -10,6 +10,6 @@ RUN apt-get update && \
     # Necessary packages for entrypoint.sh
     apt-get -y install gosu bash
 
-RUN go install goa.design/goa/v3/cmd/goa@v3
+RUN go install goa.design/goa/v3/cmd/goa@v3.11.1
 
 COPY go.mod go.sum /server/


### PR DESCRIPTION
* goaのバージョンは今までざっくりv3と指定していたが、最近のアップデートによりgo1.20以上を要求するようになったため、アプデ前のv3.11.1で固定した
  * 本来はgoのversionをあげればいいが、取り急ぎ
* #255 で使われていないと思っていたmakeターゲットである`client/dist`を削除したが、これは実は`client build`のworkflowで使われていたので復活させた