### PR TITLE
サインアップ時に、`username`の形式をチェック

### DIFF
--- a/client/src/components/organisms/forms/helper.tsx
+++ b/client/src/components/organisms/forms/helper.tsx
@@ -6,8 +6,10 @@ import { UpdatePasswordForm } from "~/components/organisms/forms/UpdatePasswordF
  * invalid_formだった場合のエラー表示文
  */
 const messagesOnInvalidFormError = {
-  username: "適切なユーザーネームではありません。",
-  password: "大文字・小文字・数字・記号を含む８文字以上である必要があります。",
+  username:
+    "小文字・数字・ハイフンのみを含む３９文字以内の文字列である必要があります。（ハイフンは頭と末尾に来てはいけません。）",
+  password:
+    "大文字・小文字・数字・記号を含む８文字以上の文字列である必要があります。",
   email: "適切なEmailアドレスではありません。",
   wallet_address: "適切なwallet addressではありません。",
   password_confirmation: "パスワードが一致していません。",

--- a/infrastructure/function_scripts/pkg/models/sign_up_form.go
+++ b/infrastructure/function_scripts/pkg/models/sign_up_form.go
@@ -8,7 +8,7 @@ import (
 )
 
 type SignUpForm struct {
-	UserName string `json:"username" validate:"required"`
+	UserName string `json:"username" validate:"required,cognito_username"`
 	Password string `json:"password" validate:"required,cognito_password"`
 	Email    string `json:"email" validate:"required,email"`
 }


### PR DESCRIPTION
Closes #234 

Cognito自体は任意の言語の文字を許容していそう（参考： https://stackoverflow.com/questions/44179337/usernames-regular-expression-in-aws-cognito ）だが、lambdaでのvalidationでは、より厳しく、githubと同様の制約とした（参考： https://qiita.com/KEINOS/items/34041c94913b7bed7431 ）